### PR TITLE
[FEAT] 프리랜서 등급 산정 기반 로직 추가

### DIFF
--- a/backend/src/main/java/com/devnear/web/domain/freelancer/FreelancerProfile.java
+++ b/backend/src/main/java/com/devnear/web/domain/freelancer/FreelancerProfile.java
@@ -89,12 +89,15 @@ public class FreelancerProfile extends BaseTimeEntity {
     }
     // 완료 프로젝트 수 갱신
     public void updateCompletedProjects(Integer completedProjects) {
+        if (completedProjects == null || completedProjects < 0) {
+            throw new IllegalArgumentException("completedProjects must be >= 0");
+        }
         this.completedProjects = completedProjects;
     }
 
     // 완료 프로젝트 수 1 증가
     public void increaseCompletedProjects() {
-        if (this.completedProjects == null) {
+        if (this.completedProjects == null || this.completedProjects < 0) {
             this.completedProjects = 0;
         }
         this.completedProjects++;

--- a/backend/src/main/java/com/devnear/web/domain/freelancer/FreelancerProfile.java
+++ b/backend/src/main/java/com/devnear/web/domain/freelancer/FreelancerProfile.java
@@ -87,6 +87,18 @@ public class FreelancerProfile extends BaseTimeEntity {
         // [추가] 500 NPE 에러 방어: Builder로 생성 시 컬렉션이 null이 되지 않도록 빈 리스트로 명시적 초기화
         this.freelancerSkills = new ArrayList<>();
     }
+    // 완료 프로젝트 수 갱신
+    public void updateCompletedProjects(Integer completedProjects) {
+        this.completedProjects = completedProjects;
+    }
+
+    // 완료 프로젝트 수 1 증가
+    public void increaseCompletedProjects() {
+        if (this.completedProjects == null) {
+            this.completedProjects = 0;
+        }
+        this.completedProjects++;
+    }
 
     // [비즈니스 로직] 기본 프로필 데이터 일괄 수정
     public void updateProfile(String profileImageUrl, String introduction, String location, Double latitude,

--- a/backend/src/main/java/com/devnear/web/domain/portfolio/PortfolioRepository.java
+++ b/backend/src/main/java/com/devnear/web/domain/portfolio/PortfolioRepository.java
@@ -16,4 +16,7 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
             "LEFT JOIN FETCH p.portfolioImages " +
             "WHERE p.user.id = :userId")
     List<Portfolio> findByUserIdWithSkills(@Param("userId") Long userId);
+
+    // 특정 유저가 등록한 포트폴리오 개수 조회(등급산정용)
+    long countByUser_Id(Long userId);
 }

--- a/backend/src/main/java/com/devnear/web/service/freelancer/FreelancerGradeService.java
+++ b/backend/src/main/java/com/devnear/web/service/freelancer/FreelancerGradeService.java
@@ -1,0 +1,72 @@
+package com.devnear.web.service.freelancer;
+
+import com.devnear.web.domain.freelancer.FreelancerGrade;
+import com.devnear.web.domain.freelancer.FreelancerGradeRepository;
+import com.devnear.web.domain.freelancer.FreelancerProfile;
+import com.devnear.web.domain.portfolio.PortfolioRepository;
+import com.devnear.web.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FreelancerGradeService {
+
+    private final FreelancerGradeRepository freelancerGradeRepository;
+    private final PortfolioRepository portfolioRepository;
+
+    @Transactional
+    public void refreshGrade(FreelancerProfile freelancerProfile) {
+        FreelancerGrade targetGrade = calculateGrade(freelancerProfile);
+        freelancerProfile.updateGrade(targetGrade);
+    }
+
+    public FreelancerGrade calculateGrade(FreelancerProfile freelancerProfile) {
+        int completedProjects = safeInt(freelancerProfile.getCompletedProjects());
+        double averageRating = safeDouble(freelancerProfile.getAverageRating());
+        int reviewCount = safeInt(freelancerProfile.getReviewCount());
+        long portfolioCount = portfolioRepository.countByUser_Id(freelancerProfile.getUser().getId());
+
+        long activeMonths = 0;
+        if (freelancerProfile.getCreatedAt() != null) {
+            activeMonths = ChronoUnit.MONTHS.between(
+                    freelancerProfile.getCreatedAt().toLocalDate(),
+                    LocalDate.now()
+            );
+        }
+
+        if (completedProjects >= 10
+                && averageRating >= 4.5
+                && reviewCount >= 20
+                && portfolioCount >= 3
+                && activeMonths >= 3) {
+            return getGradeOrThrow("TOP Talent");
+        }
+
+        if (completedProjects >= 3
+                && averageRating >= 4.0
+                && portfolioCount >= 1) {
+            return getGradeOrThrow("인증 프리랜서");
+        }
+
+        return getGradeOrThrow("일반");
+    }
+
+    private FreelancerGrade getGradeOrThrow(String name) {
+        return freelancerGradeRepository.findByName(name)
+                .orElseThrow(() -> new ResourceNotFoundException("프리랜서 등급 데이터가 없습니다: " + name));
+    }
+
+    private int safeInt(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private double safeDouble(Double value) {
+        return value == null ? 0.0 : value;
+    }
+}

--- a/backend/src/main/java/com/devnear/web/service/freelancer/FreelancerGradeService.java
+++ b/backend/src/main/java/com/devnear/web/service/freelancer/FreelancerGradeService.java
@@ -37,10 +37,10 @@ public class FreelancerGradeService {
 
         long activeMonths = 0;
         if (freelancerProfile.getCreatedAt() != null) {
-            activeMonths = ChronoUnit.MONTHS.between(
+            activeMonths = Math.max(0, ChronoUnit.MONTHS.between(
                     freelancerProfile.getCreatedAt().toLocalDate(),
                     LocalDate.now()
-            );
+            ));
         }
 
         if (completedProjects >= 10

--- a/backend/src/main/java/com/devnear/web/service/freelancer/FreelancerGradeService.java
+++ b/backend/src/main/java/com/devnear/web/service/freelancer/FreelancerGradeService.java
@@ -27,6 +27,9 @@ public class FreelancerGradeService {
     }
 
     public FreelancerGrade calculateGrade(FreelancerProfile freelancerProfile) {
+        if (freelancerProfile == null || freelancerProfile.getUser() == null || freelancerProfile.getUser().getId() == null) {
+            throw new IllegalArgumentException("freelancerProfile.user.id is required");
+        }
         int completedProjects = safeInt(freelancerProfile.getCompletedProjects());
         double averageRating = safeDouble(freelancerProfile.getAverageRating());
         int reviewCount = safeInt(freelancerProfile.getReviewCount());


### PR DESCRIPTION


## 🔎 What

- FreelancerGradeRepository 추가
PortfolioRepository에 포트폴리오 개수 조회 메서드 추가
FreelancerGradeService 추가
FreelancerProfile에 등급 갱신 및 완료 프로젝트 수 관련 메서드 추가

## 상세설명
기획안에 정의된 프리랜서 등급 정책(일반 / 인증 프리랜서 / TOP Talent)을 반영하기 위한 기반 로직을 추가했습니다. 기존 FreelancerGrade 엔티티를 활용해 완료 프로젝트 수, 평균 평점, 리뷰 수, 포트폴리오 수, 활동 기간을 기준으로 목표 등급을 계산하는 FreelancerGradeService를 구현했습니다.

## 🔗 Issue

- Closes: #29

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?


## 이후 예정 작업
프로젝트 완료 시 완료 건수 증가 + 등급 자동 갱신 연결
리뷰 등록 시 등급 자동 갱신 연결
포트폴리오 변경 시 등급 자동 갱신 연결
공용 DB 초기 데이터 마이그레이션 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated freelancer grading service that assigns tiered badges (TOP Talent, Certified Freelancer, General) from profile metrics.

* **Enhancements**
  * Validated completed-project counts on freelancer profiles, with safe incrementing to prevent invalid values.
  * Portfolio counts and profile activity are incorporated when recalculating and persisting up-to-date grades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->