### PR TITLE
[Feat]#46 리뷰등록시 등급 반영 및 포트폴리오 삭제시 등급 변동

### DIFF
--- a/backend/src/main/java/com/devnear/web/domain/freelancer/FreelancerProfileRepository.java
+++ b/backend/src/main/java/com/devnear/web/domain/freelancer/FreelancerProfileRepository.java
@@ -3,13 +3,19 @@ package com.devnear.web.domain.freelancer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.Lock;
 
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import java.util.List;
 
 public interface FreelancerProfileRepository extends JpaRepository<FreelancerProfile, Long> {
     
     Optional<FreelancerProfile> findByUser_Id(Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT fp FROM FreelancerProfile fp WHERE fp.id = :id")
+    Optional<FreelancerProfile> findByIdForUpdate(@Param("id") Long id);
 
     @Query("SELECT DISTINCT fp FROM FreelancerProfile fp " +
            "LEFT JOIN FETCH fp.freelancerSkills fs " +

--- a/backend/src/main/java/com/devnear/web/service/portfolio/PortfolioService.java
+++ b/backend/src/main/java/com/devnear/web/service/portfolio/PortfolioService.java
@@ -14,6 +14,9 @@ import com.devnear.web.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.devnear.web.domain.freelancer.FreelancerProfile;
+import com.devnear.web.domain.freelancer.FreelancerProfileRepository;
+import com.devnear.web.service.freelancer.FreelancerGradeService;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,6 +28,8 @@ public class PortfolioService {
 
     private final PortfolioRepository portfolioRepository;
     private final SkillRepository skillRepository;
+    private final FreelancerProfileRepository freelancerProfileRepository;
+    private final FreelancerGradeService freelancerGradeService;
 
     // [등록] POST /api/portfolios
     @Transactional
@@ -69,7 +74,14 @@ public class PortfolioService {
         }
 
         // 4. 저장 후 생성된 ID 반환
-        return portfolioRepository.save(portfolio).getId();
+        Long savedId = portfolioRepository.save(portfolio).getId();
+
+        // 등급 재계산
+        FreelancerProfile freelancerProfile = freelancerProfileRepository.findByUser_Id(user.getId())
+                .orElseThrow(() -> new IllegalArgumentException("현재 사용자에 대한 프리랜서 프로필을 찾을 수 없습니다."));
+        freelancerGradeService.refreshGrade(freelancerProfile);
+
+        return savedId;
     }
 
     // [조회] GET /api/portfolios (특정 유저의 목록 반환)
@@ -95,6 +107,11 @@ public class PortfolioService {
 
         // 3. 권한 문제없으면 삭제 실행 (Cascade 속성으로 인해 딸려있던 기술스택 데이터도 알아서 날아감)
         portfolioRepository.delete(portfolio);
+
+        // 등급 재계산
+        FreelancerProfile freelancerProfile = freelancerProfileRepository.findByUser_Id(user.getId())
+                .orElseThrow(() -> new IllegalArgumentException("현재 사용자에 대한 프리랜서 프로필을 찾을 수 없습니다."));
+        freelancerGradeService.refreshGrade(freelancerProfile);
     }
 
     // [수정] PUT /api/portfolios/{id}
@@ -143,5 +160,9 @@ public class PortfolioService {
                     .skill(skill)
                     .build());
         }
+        // 7. 등급 재계산
+        FreelancerProfile freelancerProfile = freelancerProfileRepository.findByUser_Id(user.getId())
+                .orElseThrow(() -> new IllegalArgumentException("현재 사용자에 대한 프리랜서 프로필을 찾을 수 없습니다."));
+        freelancerGradeService.refreshGrade(freelancerProfile);
     }
 }

--- a/backend/src/main/java/com/devnear/web/service/review/ReviewService.java
+++ b/backend/src/main/java/com/devnear/web/service/review/ReviewService.java
@@ -20,6 +20,7 @@ import com.devnear.web.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.devnear.web.service.freelancer.FreelancerGradeService;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -35,6 +36,7 @@ public class ReviewService {
     private final ClientProfileRepository clientProfileRepository;
     private final FreelancerProfileRepository freelancerProfileRepository;
     private final ProjectRepository projectRepository;
+    private final FreelancerGradeService freelancerGradeService;
 
     @Transactional
     public Long createFreelancerReview(User user, FreelancerReviewCreateRequest request) {
@@ -83,9 +85,10 @@ public class ReviewService {
                 .comment(request.getComment())
                 .build();
 
-        // 저장 후 평점 재계산
+        // 저장 후 평점 및 등급 재계산
         freelancerReviewRepository.save(review);
         updateFreelancerRating(freelancer);
+        freelancerGradeService.refreshGrade(freelancer);
 
         return review.getId();
     }

--- a/backend/src/main/java/com/devnear/web/service/review/ReviewService.java
+++ b/backend/src/main/java/com/devnear/web/service/review/ReviewService.java
@@ -85,10 +85,9 @@ public class ReviewService {
                 .comment(request.getComment())
                 .build();
 
-        // 저장 후 평점 및 등급 재계산
+        // 저장 후 평점 및 등급 재계산 (동시성 보호를 위해 잠금된 프로필을 사용하여 재계산)
         freelancerReviewRepository.save(review);
-        updateFreelancerRating(freelancer);
-        freelancerGradeService.refreshGrade(freelancer);
+        recomputeFreelancerAggregates(freelancer.getId());
 
         return review.getId();
     }
@@ -190,6 +189,34 @@ public class ReviewService {
 
         freelancer.updateAverageRating(average.doubleValue());
         freelancer.updateReviewCount(reviews.size());
+    }
+
+    /**
+     * Recompute aggregates with pessimistic lock to avoid lost updates when multiple reviews are created concurrently.
+     */
+    @Transactional
+    public void recomputeFreelancerAggregates(Long freelancerId) {
+        // obtain PESSIMISTIC_WRITE lock on freelancer profile
+        FreelancerProfile locked = freelancerProfileRepository.findByIdForUpdate(freelancerId)
+                .orElseThrow(() -> new ResourceNotFoundException("프리랜서 프로필이 없습니다."));
+
+        List<FreelancerReview> reviews = freelancerReviewRepository.findByFreelancer(locked);
+
+        if (reviews.isEmpty()) {
+            locked.updateAverageRating(0.0);
+            locked.updateReviewCount(0);
+        } else {
+            BigDecimal average = reviews.stream()
+                    .map(FreelancerReview::getAverageScore)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add)
+                    .divide(BigDecimal.valueOf(reviews.size()), 2, RoundingMode.HALF_UP);
+
+            locked.updateAverageRating(average.doubleValue());
+            locked.updateReviewCount(reviews.size());
+        }
+
+        // Refresh grade using the locked, managed entity so grade calculation uses latest persisted aggregates
+        freelancerGradeService.refreshGrade(locked);
     }
 
     @Transactional


### PR DESCRIPTION

## 🔎 What

- 프리랜서 리뷰 작성 후 평균 평점과 리뷰 수가 갱신된 뒤, 프리랜서 등급도 함께 재계산되도록 로직을 추가ReviewService.createFreelancerReview()에서 리뷰 저장 이후 updateFreelancerRating()을 호출한 다음 FreelancerGradeService.refreshGrade()를 실행하도록 연결해, 리뷰 누적 결과가 등급 산정에 반영되도록 구현했다


## 🔗 Issue

- Closes: #46

## ✅ 체크리스트

- [ ] 브랜치 base가 적절한가요?
- [ ] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Freelancer grades now refresh automatically when reviews are created, ensuring ratings and grades are immediately up-to-date.
  * Freelancer grades now also refresh after portfolio changes (create, update, delete), keeping ratings and grades consistent following portfolio edits.
  * Improved grade recomputation to reduce timing-related inconsistencies, resulting in more reliable displayed ratings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->