### PR TITLE
feat : 대시보드 북마크, 제안내역 조회 api 연동

### DIFF
--- a/backend/src/main/java/com/devnear/web/service/project/ProjectService.java
+++ b/backend/src/main/java/com/devnear/web/service/project/ProjectService.java
@@ -16,13 +16,13 @@ import com.devnear.web.dto.project.ProjectResponse;
 import com.devnear.web.exception.ProjectAccessDeniedException;
 import com.devnear.web.exception.ResourceNotFoundException;
 import com.devnear.web.service.freelancer.FreelancerGradeService;
+import jakarta.persistence.EntityManager; // 🔍 추가
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,6 +42,7 @@ public class ProjectService {
     private final ClientProfileRepository clientProfileRepository;
     private final SkillRepository skillRepository;
     private final FreelancerGradeService freelancerGradeService;
+    private final EntityManager em; // 🔍 직접 플러시를 위해 주입
 
     @Transactional
     public Long createProject(User user, ProjectRequest request) {
@@ -58,11 +59,6 @@ public class ProjectService {
             mapSkillsToProject(project, skills);
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("새 프로젝트 등록 - ID: {}, 작성자: {}, 오프라인: {}, 주소: {}",
-                    project.getId(), user.getEmail(), request.isOffline(), maskAddress(request.getLocation()));
-        }
-
         return project.getId();
     }
 
@@ -74,11 +70,20 @@ public class ProjectService {
             log.debug("프로젝트 수정 시도 - ID: {}, 사용자: {}", projectId, user.getEmail());
         }
 
+        // 1. 기본 정보 업데이트
         project.update(request);
 
+        // 2. 기술 스택 업데이트 로직 개선
         if (request.hasSkillPayload()) {
             List<Skill> skills = resolveSkills(request);
-            project.updateSkills(Collections.emptyList());
+
+            // 🔍 [지리는 해결책]
+            // JPA는 변경 사항을 모았다가 나중에 한 번에 쏘는데, 보통 INSERT를 DELETE보다 먼저 실행함.
+            // 그래서 Duplicate Entry 에러가 발생함.
+            // 이를 해결하기 위해 기존 리스트를 비우고 강제로 flush()를 호출해 DELETE를 즉시 실행함.
+            project.getProjectSkills().clear();
+            em.flush(); // 🔥 여기서 즉시 DELETE SQL 실행!
+
             if (!skills.isEmpty()) {
                 mapSkillsToProject(project, skills);
             }
@@ -93,8 +98,11 @@ public class ProjectService {
                         .build())
                 .collect(Collectors.toList());
 
+        // 이미 updateProject에서 clear()와 flush()를 했으므로 바로 addAll() 느낌으로 작동
         project.updateSkills(projectSkills);
     }
+
+    // --- 이하 기존 로직 보존 ---
 
     private List<Skill> resolveSkills(ProjectRequest request) {
         Set<Skill> resolvedSkills = new LinkedHashSet<>();
@@ -151,17 +159,13 @@ public class ProjectService {
     public void deleteProject(User user, Long projectId) {
         Project project = findProjectAndValidateOwner(user, projectId);
         projectRepository.delete(project);
-
-        log.info("프로젝트 삭제 완료 - ID: {}, 삭제자: {}", projectId, user.getEmail());
     }
 
     @Transactional(readOnly = true)
     public Page<ProjectResponse> getProjectList(Pageable pageable) {
-        return projectRepository.findAll(pageable)
-                .map(ProjectResponse::from);
+        return projectRepository.findAll(pageable).map(ProjectResponse::from);
     }
 
-    // [수정] 프론트엔드 리뷰 반영: activeTab(온/오프라인) 추가
     @Transactional(readOnly = true)
     public Page<ProjectResponse> searchProjects(String keyword, String location, String skill, Boolean online, Boolean offline, Pageable pageable) {
         String safeKeyword = (keyword != null && keyword.trim().isEmpty()) ? null : keyword;
@@ -190,12 +194,6 @@ public class ProjectService {
                 .orElseThrow(() -> new ResourceNotFoundException("해당 프로젝트 공고를 찾을 수 없습니다. ID: " + projectId));
 
         return ProjectResponse.from(project);
-    }
-
-    @Transactional(readOnly = true)
-    public Page<ProjectResponse> searchProjects(ProjectSearchCond cond, Pageable pageable) {
-        return projectRepository.search(cond, pageable)
-                .map(ProjectResponse::from);
     }
 
     private ClientProfile findClientProfileByUser(User user) {
@@ -233,11 +231,8 @@ public class ProjectService {
     @Transactional
     public void completeProject(User user, Long projectId) {
         Project project = findProjectAndValidateOwner(user, projectId);
-
-        // 프로젝트 상태 완료 처리
         project.complete();
 
-        // 연결된 프리랜서가 있으면 완료 프로젝트 수 증가 + 등급 재계산
         FreelancerProfile freelancerProfile = project.getFreelancerProfile();
         if (freelancerProfile != null) {
             freelancerProfile.increaseCompletedProjects();

--- a/frontend/app/client/dashboard/page.tsx
+++ b/frontend/app/client/dashboard/page.tsx
@@ -4,20 +4,33 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import api from '@/app/lib/axios';
 import { NotificationBell } from '@/components/notifications/NotificationProvider';
-import { User, Users, CheckCircle, XCircle, Edit, Trash2, Calendar, DollarSign, Activity, ChevronRight, Briefcase } from 'lucide-react';
-
+import {
+    User, Users, CheckCircle, XCircle, Edit, Trash2,
+    Calendar, DollarSign, Activity, ChevronRight,
+    Briefcase, Heart, Send, Sparkles, Star, MapPin, Globe, Loader2, Clock, ArrowUpRight, Plus
+} from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 export default function ClientDashboardPage() {
     const router = useRouter();
     const [projects, setProjects] = useState<any[]>([]);
+    const [bookmarks, setBookmarks] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
+    const [bookmarksLoading, setBookmarksLoading] = useState(false);
     const [authorized, setAuthorized] = useState(false);
 
+    const [activeMainTab, setActiveMainTab] = useState<'PROJECTS' | 'BOOKMARKS' | 'PROPOSALS'>('PROJECTS');
     const [filterStatus, setFilterStatus] = useState<string>('ALL');
+
+    // 🎯 [지원자 관리] 상태
+    const [expandedProjectId, setExpandedProjectId] = useState<number | null>(null);
+    const [applicantsByProject, setApplicantsByProject] = useState<{ [key: number]: any[] }>({});
+    const [loadingApplicants, setLoadingApplicants] = useState<{ [key: number]: boolean }>({});
     const [selectedProjectForApplicant, setSelectedProjectForApplicant] = useState<any>(null);
-    const [applicants, setApplicants] = useState<any[]>([]);
-    const [isApplicantModalOpen, setIsApplicantModalOpen] = useState(false);
+
+    // 🎯 [역제안 관리] 신규 상태
+    const [sentProposals, setSentProposals] = useState<any[]>([]);
+    const [proposalsLoading, setProposalsLoading] = useState(false);
 
     const [cursor, setCursor] = useState({ x: 0, y: 0 });
 
@@ -32,16 +45,11 @@ export default function ClientDashboardPage() {
             try {
                 const res = await api.get("/v1/users/me");
                 const roles = res.data.role || "";
-                
-                // [Fix] Coderabbit 리뷰 반영: BOTH 계정도 클라이언트 페이지에 접근 가능하도록 수정
                 if (!roles.includes("CLIENT") && !roles.includes("BOTH")) {
                     alert("클라이언트 또는 BOTH 계정만 접근 가능합니다.");
                     if (roles.includes("FREELANCER")) return router.replace("/");
                     return router.replace("/onboarding");
                 }
-                
-                // [Fix] Coderabbit 리뷰 반영: GUEST 권한 체크 중복(Dead code) 제거
-                
                 setAuthorized(true);
             } catch (err) {
                 router.replace("/login");
@@ -50,75 +58,94 @@ export default function ClientDashboardPage() {
         checkAccess();
     }, [router]);
 
+    // 1. 운영 프로젝트 조회
     const fetchMyProjects = async () => {
         try {
             const { data } = await api.get('/v1/projects/me');
             const projectArray = data.content || data || [];
             setProjects(projectArray.filter((p: any) => p.status !== 'COMPLETED'));
+        } catch (err) { console.error("로드 실패", err); } finally { setLoading(false); }
+    };
+
+    // 2. 관심 인재 조회
+    const fetchBookmarks = async () => {
+        setBookmarksLoading(true);
+        try {
+            const { data } = await api.get('/bookmarks/freelancers');
+            setBookmarks(data.content || []);
+        } catch (err) { console.error("찜 목록 로드 실패", err); } finally { setBookmarksLoading(false); }
+    };
+
+    // 3. 🔍 [NEW] 보낸 역제안 목록 조회
+    const fetchSentProposals = async () => {
+        setProposalsLoading(true);
+        try {
+            const { data } = await api.get('/v1/proposals/sent');
+            setSentProposals(data || []);
         } catch (err) {
-            console.error("로드 실패", err);
+            console.error("제안 로드 실패", err);
         } finally {
-            setLoading(false);
+            setProposalsLoading(false);
         }
     };
 
-    useEffect(() => { if (authorized) fetchMyProjects(); }, [authorized]);
-
-    const handleEditProjectClick = (projectId: number) => {
-        router.push(`/client/projects/${projectId}/edit`);
+    const handleRemoveBookmark = async (profileId: number) => {
+        if (!confirm("찜 목록에서 삭제하시겠습니까?")) return;
+        try {
+            await api.delete(`/bookmarks/freelancers/${profileId}`);
+            fetchBookmarks();
+        } catch (err) { alert("삭제에 실패했습니다."); }
     };
 
+    useEffect(() => {
+        if (authorized) {
+            if (activeMainTab === 'PROJECTS') fetchMyProjects();
+            if (activeMainTab === 'BOOKMARKS') fetchBookmarks();
+            if (activeMainTab === 'PROPOSALS') fetchSentProposals(); // 역제안 탭 활성화 시 호출
+        }
+    }, [authorized, activeMainTab]);
+
+    // 기존 프로젝트 수정/삭제/지원자 핸들러 (유지)
+    const handleEditProjectClick = (projectId: number) => router.push(`/client/projects/${projectId}/edit`);
     const handleStatusChange = async (projectId: number, action: 'start' | 'close') => {
         const msg = action === 'start' ? '시작' : '마감';
         if (!confirm(`프로젝트를 ${msg} 처리하시겠습니까?`)) return;
-        try {
-            await api.patch(`/v1/projects/${projectId}/${action}`);
-            fetchMyProjects();
-        } catch (err) {
-            alert('상태 변경 실패');
-        }
+        try { await api.patch(`/v1/projects/${projectId}/${action}`); fetchMyProjects(); } catch (err) { alert('상태 변경 실패'); }
     };
-
     const handleDeleteProject = async (projectId: number) => {
         if (!confirm('정말 삭제하시겠습니까?')) return;
-        try {
-            await api.delete(`/v1/projects/${projectId}`);
-            fetchMyProjects();
-        } catch (err) {
-            alert('삭제 실패');
-        }
+        try { await api.delete(`/v1/projects/${projectId}`); fetchMyProjects(); } catch (err) { alert('삭제 실패'); }
     };
 
     const handleViewApplicants = async (project: any) => {
+        const pid = project.projectId;
+        if (expandedProjectId === pid) { setExpandedProjectId(null); return; }
         setSelectedProjectForApplicant(project);
-        setIsApplicantModalOpen(true);
+        setExpandedProjectId(pid);
+        if (applicantsByProject[pid]) return;
+        setLoadingApplicants(prev => ({ ...prev, [pid]: true }));
         try {
-            const { data } = await api.get(`/projects/${project.projectId}/applications`);
-            setApplicants(data);
-        } catch (err) {
-            console.error("지원자 로드 실패:", err);
-            setApplicants([]);
-        }
+            const { data } = await api.get(`/projects/${pid}/applications`);
+            setApplicantsByProject(prev => ({ ...prev, [pid]: data }));
+        } catch (err) { setApplicantsByProject(prev => ({ ...prev, [pid]: [] })); }
+        finally { setLoadingApplicants(prev => ({ ...prev, [pid]: false })); }
     };
 
     const handleApplicationStatus = async (applicationId: number, status: 'ACCEPTED' | 'REJECTED') => {
         try {
             await api.patch(`/applications/${applicationId}/status`, { status });
             alert(`지원자가 ${status === 'ACCEPTED' ? '수락' : '거절'} 처리되었습니다.`);
-            
             if (selectedProjectForApplicant) {
-                handleViewApplicants(selectedProjectForApplicant);
+                const { data } = await api.get(`/projects/${selectedProjectForApplicant.projectId}/applications`);
+                setApplicantsByProject(prev => ({ ...prev, [selectedProjectForApplicant.projectId]: data }));
             }
             fetchMyProjects();
-        } catch (err) {
-            console.error(err);
-            alert('상태 처리 중 오류가 발생했습니다.');
-        }
+        } catch (err) { alert('상태 처리 중 오류가 발생했습니다.'); }
     };
 
     if (!authorized || loading) return (
-        <div className="flex min-h-screen items-center justify-center bg-zinc-50 text-[#FF7D00] font-black text-xl animate-pulse">
-            권한 확인 중...
+        <div className="flex min-h-screen items-center justify-center bg-zinc-50 text-[#FF7D00] font-black text-xl animate-pulse uppercase font-mono">
+            Checking_Authorization...
         </div>
     );
 
@@ -134,190 +161,226 @@ export default function ClientDashboardPage() {
                     <span className="text-[#FF7D00]">Dev</span><span className="text-[#7A4FFF]">Near</span>
                 </div>
                 <div className="flex gap-4 items-center relative z-10 md:gap-6">
-                    <button onClick={() => router.push('/client/mypage')} className="text-xs font-black text-zinc-500 hover:text-zinc-950 tracking-widest transition uppercase font-mono">
-                        MY_PAGE
-                    </button>
+                    <button onClick={() => router.push('/client/mypage')} className="text-xs font-black text-zinc-500 hover:text-zinc-950 tracking-widest transition uppercase font-mono">MY_PAGE</button>
                     <NotificationBell />
-                    <button onClick={() => router.push("/client/projects/new")} className="px-6 py-2.5 bg-[#FF7D00] text-white rounded-xl text-xs font-black tracking-widest hover:brightness-110 transition shadow-lg shadow-orange-100 uppercase font-mono">
-                        Register_Project
-                    </button>
+                    <button onClick={() => router.push("/client/projects/new")} className="px-6 py-2.5 bg-[#FF7D00] text-white rounded-xl text-xs font-black tracking-widest hover:brightness-110 transition shadow-lg shadow-orange-100 uppercase font-mono">Register_Project</button>
                 </div>
             </nav>
 
             <header className="relative pt-16 pb-12 px-8 bg-white border-b border-zinc-200 overflow-hidden">
-                <div className="absolute inset-0 pointer-events-none opacity-[0.03]">
-                    <div className="absolute inset-0" style={{ backgroundImage: 'linear-gradient(#000 1px, transparent 1px), linear-gradient(90deg, #000 1px, transparent 1px)', backgroundSize: '50px 50px' }}></div>
-                </div>
                 <div className="max-w-5xl mx-auto relative z-10">
                     <div className="flex items-center gap-2 mb-4">
                         <span className="w-8 h-[2px] bg-[#FF7D00]"></span>
-                        <span className="text-[10px] font-black text-zinc-400 uppercase tracking-[0.3em] font-mono">Project_Management</span>
+                        <span className="text-[10px] font-black text-zinc-400 uppercase tracking-[0.3em] font-mono">Work_Hub</span>
                     </div>
-                    <h1 className="text-4xl font-black tracking-tight mb-2">대시보드</h1>
-                    <p className="text-zinc-500 font-medium">운영 중인 프로젝트와 지원자 현황을 한눈에 관리하세요.</p>
-                </div>
-            </header>
+                    <h1 className="text-4xl font-black tracking-tight mb-8">대시보드</h1>
 
-            <main className="max-w-5xl mx-auto px-8 py-12 relative z-10">
-                <div className="flex flex-col md:flex-row md:items-center justify-between mb-10 gap-6">
-                    <h2 className="text-xl font-black tracking-tight text-zinc-950 uppercase font-mono">
-                        내 프로젝트 <span className="text-[#FF7D00] ml-1">[{filteredProjects.length}]</span>
-                    </h2>
-                    <div className="flex gap-1.5 p-1.5 bg-white border border-zinc-200 rounded-2xl shadow-sm overflow-x-auto no-scrollbar">
+                    <div className="flex gap-8 border-b border-zinc-100">
                         {[
-                            { id: 'ALL', label: '전체' },
-                            { id: 'OPEN', label: '모집중' },
-                            { id: 'IN_PROGRESS', label: '진행중' },
-                            { id: 'CLOSED', label: '마감됨' }
-                        ].map((s) => (
-                            <button key={s.id} onClick={() => setFilterStatus(s.id)} className={`px-5 py-2 rounded-xl text-[10px] font-black transition-all tracking-widest uppercase font-mono ${filterStatus === s.id ? 'bg-zinc-950 text-white shadow-md' : 'text-zinc-400 hover:text-zinc-600'}`}>
-                                {s.label}
+                            { id: 'PROJECTS', label: '운영 프로젝트', icon: <Briefcase size={16} /> },
+                            { id: 'BOOKMARKS', label: '관심 인재', icon: <Heart size={16} /> },
+                            { id: 'PROPOSALS', label: '제안 현황', icon: <Send size={16} /> }
+                        ].map((tab) => (
+                            <button
+                                key={tab.id}
+                                onClick={() => setActiveMainTab(tab.id as any)}
+                                className={`flex items-center gap-2 pb-4 text-sm font-black transition-all relative ${
+                                    activeMainTab === tab.id ? 'text-[#FF7D00]' : 'text-zinc-400 hover:text-zinc-600'
+                                }`}
+                            >
+                                {tab.icon} {tab.label}
+                                {activeMainTab === tab.id && (
+                                    <motion.div layoutId="activeTab" className="absolute bottom-0 left-0 right-0 h-1 bg-[#FF7D00] rounded-t-full" />
+                                )}
                             </button>
                         ))}
                     </div>
                 </div>
+            </header>
 
-                <div className="grid gap-6">
-                    {filteredProjects.length === 0 ? (
-                        <div className="text-center py-24 bg-white rounded-2xl border-2 border-dashed border-zinc-200 font-bold text-zinc-300 italic font-mono uppercase tracking-tighter">Null: No_Projects_Found</div>
-                    ) : (
-                        filteredProjects.map((project, idx) => (
-                            <motion.div initial={{ y: 20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ delay: idx * 0.05 }} key={project.projectId}
-                                        className="group bg-white p-8 rounded-2xl border border-zinc-100 flex flex-col md:flex-row justify-between items-center transition-all hover:border-[#FF7D00] hover:shadow-xl hover:shadow-orange-100/50">
-                                <div className="flex-1 w-full">
-                                    <div className="flex items-center gap-3 mb-4">
-                                        <span className={`px-3 py-1 rounded-md text-[10px] font-black tracking-widest uppercase font-mono border ${project.status === 'OPEN' ? 'bg-[#FF7D00]/10 text-[#FF7D00] border-[#FF7D00]/20' : project.status === 'IN_PROGRESS' ? 'bg-orange-50 text-[#FF7D00] border-orange-100' : 'bg-zinc-100 text-zinc-500'}`}>
-                                            {project.status === 'OPEN' ? '모집중' : project.status === 'IN_PROGRESS' ? '진행중' : '마감됨'}
-                                        </span>
-                                        <span className="text-[10px] font-bold text-zinc-300 font-mono tracking-widest uppercase">ID_{project.projectId}</span>
-                                    </div>
-                                    <h3 className="text-2xl font-black text-zinc-900 group-hover:text-[#FF7D00] transition-colors mb-4 tracking-tight">{project.projectName}</h3>
-                                    <div className="flex flex-wrap gap-6 text-xs font-bold text-zinc-400 font-mono uppercase">
-                                        <span className="flex items-center gap-1"><DollarSign size={14} className="text-[#FF7D00]"/>{(project.budget || 0).toLocaleString()}원</span>
-                                        <span className="flex items-center gap-1"><Calendar size={14} className="text-[#FF7D00]"/>{project.deadline} 마감</span>
-                                    </div>
-                                </div>
-                                <div className="flex items-center gap-4 mt-8 md:mt-0">
-                                    {project.status === 'OPEN' && (
-                                        <div className="flex gap-2">
-                                            <button onClick={() => handleStatusChange(project.projectId, 'start')} className="px-5 py-2.5 bg-[#FF7D00]/10 text-[#FF7D00] rounded-xl text-[10px] font-black hover:bg-[#FF7D00] hover:text-white transition-all uppercase font-mono">시작</button>
-                                            <button onClick={() => handleStatusChange(project.projectId, 'close')} className="px-5 py-2.5 bg-zinc-50 text-zinc-400 rounded-xl text-[10px] font-black hover:bg-zinc-100 transition-all uppercase font-mono tracking-widest">마감</button>
-                                        </div>
-                                    )}
-                                    <div className="flex gap-1 px-3 border-x border-zinc-100">
-                                        <button onClick={() => handleEditProjectClick(project.projectId)} className="p-3 text-zinc-300 hover:text-[#7A4FFF] transition-all"><Edit size={18} /></button>
-                                        <button onClick={() => handleDeleteProject(project.projectId)} className="p-3 text-zinc-300 hover:text-red-500 transition-all"><Trash2 size={18} /></button>
-                                    </div>
-                                    <button onClick={() => handleViewApplicants(project)} className="px-8 py-4 bg-zinc-950 text-white rounded-xl font-black text-xs tracking-widest uppercase hover:bg-[#FF7D00] transition-all flex items-center gap-2 shadow-lg shadow-zinc-200 font-mono">
-                                        <Users size={16} /> Applicants
-                                    </button>
-                                </div>
-                            </motion.div>
-                        ))
-                    )}
-                </div>
-            </main>
-
-            {/* --- 지원자 목록 모달 --- */}
-            <AnimatePresence>
-                {isApplicantModalOpen && selectedProjectForApplicant && (
-                    <div className="fixed inset-0 z-[100] flex items-center justify-center p-6">
-                        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} onClick={() => setIsApplicantModalOpen(false)} className="absolute inset-0 bg-zinc-950/60 backdrop-blur-md" />
-                        <motion.div initial={{ opacity: 0, scale: 0.95, y: 30 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.95, y: 30 }} className="relative bg-white rounded-3xl w-full max-w-2xl p-10 shadow-2xl overflow-hidden flex flex-col max-h-[85vh] border border-zinc-100">
-
-                            <div className="flex justify-between items-start mb-8">
-                                <div>
-                                    <h2 className="text-3xl font-black text-zinc-900 tracking-tight">지원자 목록</h2>
-                                    <p className="text-base font-bold text-[#FF7D00] mt-2">대상: {selectedProjectForApplicant.projectName}</p>
-                                </div>
-                                <button onClick={() => setIsApplicantModalOpen(false)} className="text-zinc-300 hover:text-[#FF7D00] p-2 bg-zinc-50 rounded-full transition-colors"><XCircle size={32} /></button>
+            <main className="max-w-5xl mx-auto px-8 py-12 relative z-10">
+                {/* 1. 운영 프로젝트 섹션 */}
+                {activeMainTab === 'PROJECTS' && (
+                    <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
+                        <div className="flex flex-col md:flex-row md:items-center justify-between mb-10 gap-6">
+                            {/* 🔍 [수정 포인트] 제목 옆에 등록 버튼 추가 */}
+                            <div className="flex items-center gap-4">
+                                <h2 className="text-xl font-black tracking-tight text-zinc-950 uppercase font-mono">내 프로젝트 <span className="text-[#FF7D00] ml-1">[{filteredProjects.length}]</span></h2>
+                                <button
+                                    onClick={() => router.push("/client/projects/new")}
+                                    className="p-2 bg-[#FF7D00]/10 text-[#FF7D00] rounded-full hover:bg-[#FF7D00] hover:text-white transition-all shadow-sm"
+                                    title="새 프로젝트 등록"
+                                >
+                                    <Plus size={20} strokeWidth={3} />
+                                </button>
                             </div>
 
-                            <div className="overflow-y-auto space-y-6 pr-2 custom-scrollbar">
-                                {applicants.length === 0 ? (
-                                    <div className="py-24 text-center text-zinc-300 font-black border-2 border-dashed border-zinc-100 rounded-2xl text-xl">
-                                        아직 지원자가 없습니다.
-                                    </div>
-                                ) : (
-                                    applicants.map((app: any) => (
-                                        <div key={app.applicationId} className="p-7 bg-zinc-50 rounded-2xl border border-zinc-100 flex flex-col gap-6 hover:bg-white hover:border-[#FF7D00] hover:shadow-lg transition-all group">
-
-                                            <div className="flex justify-between items-center w-full">
-                                                <div
-                                                    className="flex items-center gap-5 cursor-pointer group/profile"
-                                                    onClick={() => router.push(`/freelancer/${app.freelancerId}`)}
-                                                >
-                                                    <div className="w-16 h-16 rounded-2xl bg-white flex items-center justify-center text-[#FF7D00] border border-zinc-200 shadow-sm flex-shrink-0 group-hover/profile:border-[#FF7D00] transition-all">
-                                                        {app.freelancerProfileImageUrl ? (
-                                                            <img src={app.freelancerProfileImageUrl} alt="" className="w-full h-full object-cover rounded-2xl" />
+                            <div className="flex gap-1.5 p-1.5 bg-white border border-zinc-200 rounded-2xl shadow-sm">
+                                {[{ id: 'ALL', label: '전체' }, { id: 'OPEN', label: '모집중' }, { id: 'IN_PROGRESS', label: '진행중' }, { id: 'CLOSED', label: '마감됨' }].map((s) => (
+                                    <button key={s.id} onClick={() => setFilterStatus(s.id)} className={`px-5 py-2 rounded-xl text-[10px] font-black transition-all tracking-widest uppercase font-mono ${filterStatus === s.id ? 'bg-zinc-950 text-white shadow-md' : 'text-zinc-400 hover:text-zinc-600'}`}>{s.label}</button>
+                                ))}
+                            </div>
+                        </div>
+                        <div className="grid gap-6">
+                            {filteredProjects.map((project, idx) => {
+                                const isExpanded = expandedProjectId === project.projectId;
+                                const projectApplicants = applicantsByProject[project.projectId] || [];
+                                return (
+                                    <div key={project.projectId} className="flex flex-col gap-2">
+                                        <div className={`group bg-white p-8 rounded-[2rem] border transition-all ${isExpanded ? 'border-[#FF7D00] shadow-xl ring-1 ring-[#FF7D00]' : 'border-zinc-100 shadow-sm hover:border-[#FF7D00]'}`}>
+                                            <div className="flex flex-col md:flex-row justify-between items-center w-full">
+                                                <div className="flex-1 w-full">
+                                                    <span className={`px-3 py-1 rounded-md text-[10px] font-black tracking-widest uppercase font-mono border ${project.status === 'OPEN' ? 'bg-[#FF7D00]/10 text-[#FF7D00] border-[#FF7D00]/20' : 'bg-zinc-100 text-zinc-500'}`}>{project.status}</span>
+                                                    <h3 className="text-2xl font-black text-zinc-900 mt-4 group-hover:text-[#FF7D00] transition-colors tracking-tight">{project.projectName}</h3>
+                                                    <div className="flex gap-6 mt-4 text-xs font-bold text-zinc-400 font-mono uppercase">
+                                                        <span><DollarSign size={14} className="inline mr-1 text-[#FF7D00]"/>{project.budget?.toLocaleString()}원</span>
+                                                        <span><Calendar size={14} className="inline mr-1 text-[#FF7D00]"/>{project.deadline} 마감</span>
+                                                    </div>
+                                                </div>
+                                                <div className="flex items-center gap-4 mt-8 md:mt-0">
+                                                    <div className="flex gap-1 px-3 border-x border-zinc-100">
+                                                        <button onClick={() => handleEditProjectClick(project.projectId)} className="p-3 text-zinc-300 hover:text-[#7A4FFF] transition-all"><Edit size={18} /></button>
+                                                        <button onClick={() => handleDeleteProject(project.projectId)} className="p-3 text-zinc-300 hover:text-red-500 transition-all"><Trash2 size={18} /></button>
+                                                    </div>
+                                                    <button onClick={() => handleViewApplicants(project)} className={`px-8 py-4 rounded-xl font-black text-xs tracking-widest uppercase transition-all flex items-center gap-2 ${isExpanded ? 'bg-[#FF7D00] text-white shadow-orange-200' : 'bg-zinc-950 text-white shadow-zinc-200 hover:bg-[#FF7D00]'}`}>
+                                                        <Users size={16} /> Applicants {projectApplicants.length > 0 && `[${projectApplicants.length}]`}
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        {/* 지원자 리스트 인라인 확장 */}
+                                        <AnimatePresence>
+                                            {isExpanded && (
+                                                <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: "auto", opacity: 1 }} exit={{ height: 0, opacity: 0 }} className="overflow-hidden">
+                                                    <div className="mt-2 mb-10 p-2 bg-zinc-100/50 rounded-[2rem] border border-zinc-200/50">
+                                                        {loadingApplicants[project.projectId] ? (
+                                                            <div className="py-16 flex flex-col items-center justify-center gap-4 text-zinc-400 font-mono font-bold"><Loader2 className="w-8 h-8 animate-spin text-[#FF7D00]" /><span className="animate-pulse tracking-widest text-xs uppercase">Syncing_Applicants...</span></div>
+                                                        ) : projectApplicants.length === 0 ? (
+                                                            <div className="py-16 text-center text-zinc-300 font-black border-2 border-dashed border-zinc-200 rounded-[1.5rem] text-xl font-mono uppercase bg-white">No_Applicants_Yet</div>
                                                         ) : (
-                                                            <User size={32} />
+                                                            <div className="space-y-3 p-4">
+                                                                {projectApplicants.map((app: any) => (
+                                                                    <div key={app.applicationId} className={`p-6 bg-white rounded-2xl border transition-all flex flex-col md:flex-row gap-6 items-center hover:shadow-md ${app.status === 'ACCEPTED' ? 'border-[#FF7D00] shadow-md shadow-orange-50' : 'border-zinc-100'}`}>
+                                                                        <div className="flex items-center gap-5 flex-1">
+                                                                            <div className="w-14 h-14 rounded-xl bg-zinc-50 border border-zinc-100 overflow-hidden cursor-pointer" onClick={() => router.push(`/freelancer/${app.freelancerId}`)}>{app.freelancerProfileImageUrl ? <img src={app.freelancerProfileImageUrl} alt="" className="w-full h-full object-cover" /> : <div className="w-full h-full flex items-center justify-center text-zinc-300"><User size={24} /></div>}</div>
+                                                                            <div className="flex-1">
+                                                                                <div className="flex items-center gap-2 mb-1"><h4 className="font-black text-lg text-zinc-900">{app.freelancerNickname}</h4><span className="text-[10px] font-black text-[#FF7D00] bg-orange-50 px-2 py-0.5 rounded border border-orange-100 uppercase">매칭 {Math.round(app.matchingRate)}%</span></div>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div className="flex items-center gap-8 w-full md:w-auto">
+                                                                            <div className="text-right"><p className="text-xl font-black text-zinc-900 font-mono">₩{(app.bidPrice || 0).toLocaleString()}</p><p className="text-[10px] font-bold text-zinc-300 uppercase font-mono">{app.status}</p></div>
+                                                                            <div className="flex gap-2 min-w-[140px] justify-end">
+                                                                                {app.status === 'PENDING' ? (
+                                                                                    <><button onClick={() => handleApplicationStatus(app.applicationId, 'ACCEPTED')} className="px-5 py-2.5 bg-zinc-950 text-white rounded-xl text-[10px] font-black hover:bg-[#FF7D00] transition-all uppercase font-mono">수락</button><button onClick={() => handleApplicationStatus(app.applicationId, 'REJECTED')} className="px-5 py-2.5 bg-white border border-zinc-200 text-zinc-400 rounded-xl text-[10px] font-black hover:text-red-500 hover:border-red-200 transition-all uppercase font-mono">거절</button></>
+                                                                                ) : (
+                                                                                    <div className={`px-5 py-2.5 rounded-xl text-[10px] font-black flex items-center gap-2 uppercase font-mono ${app.status === 'ACCEPTED' ? 'bg-orange-50 text-[#FF7D00] border border-orange-100' : 'bg-red-50 text-red-500 border border-red-100'}`}>{app.status === 'ACCEPTED' ? <CheckCircle size={14} /> : <XCircle size={14} />}{app.status}</div>
+                                                                                )}
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                ))}
+                                                            </div>
                                                         )}
                                                     </div>
-                                                    <div>
-                                                        <h4 className="font-black text-2xl text-zinc-900 group-hover/profile:text-[#FF7D00] transition-colors flex items-center gap-2">
-                                                            {app.freelancerNickname}
-                                                            <ChevronRight size={20} className="opacity-0 group-hover/profile:opacity-100 transition-all translate-x-[-4px] group-hover/profile:translate-x-0" />
-                                                        </h4>
-                                                        <div className="flex items-center gap-3 mt-1.5">
-                                                            {/* [Fix] Coderabbit 리뷰 반영: 백엔드에서 이미 퍼센트로 반환하므로 *100 제거 */}
-                                                            <span className="text-sm font-black text-[#FF7D00] bg-white px-3 py-1 rounded border border-[#FF7D00]/20 uppercase">
-                                                                매칭률 {Math.round(app.matchingRate)}%
-                                                            </span>
-                                                            <span className="text-sm font-bold text-zinc-400">
-                                                                {app.status === 'PENDING' ? '검토 대기 중' : app.status === 'ACCEPTED' ? '수락됨' : '거절됨'}
-                                                            </span>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div className="text-right">
-                                                    <p className="text-2xl font-black text-zinc-900 italic">₩{(app.bidPrice || 0).toLocaleString()}</p>
-                                                    <p className="text-xs font-bold text-zinc-400 mt-1">{new Date(app.appliedAt).toLocaleDateString()} 지원</p>
-                                                </div>
+                                                </motion.div>
+                                            )}
+                                        </AnimatePresence>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </motion.div>
+                )}
+
+                {/* 2. 관심 인재 섹션 */}
+                {activeMainTab === 'BOOKMARKS' && (
+                    <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="space-y-8">
+                        <div className="flex items-center justify-between"><h2 className="text-xl font-black tracking-tight text-zinc-950 uppercase font-mono">관심 인재 <span className="text-[#FF7D00] ml-1">[{bookmarks.length}]</span></h2></div>
+                        {bookmarksLoading ? ( <div className="py-24 flex justify-center"><Loader2 className="w-10 h-10 animate-spin text-[#FF7D00]" /></div> ) : bookmarks.length === 0 ? ( <div className="text-center py-32 bg-white rounded-[2.5rem] border-2 border-dashed border-zinc-100 font-black text-zinc-200 italic uppercase tracking-tighter">Null: No_Bookmarked_Talents</div> ) : (
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                                {bookmarks.map((freelancer, idx) => (
+                                    <motion.div initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} transition={{ delay: idx * 0.05 }} key={freelancer.profileId} className="group bg-white p-8 rounded-3xl border border-zinc-100 hover:border-[#FF7D00] hover:shadow-2xl transition-all relative">
+                                        <button onClick={() => handleRemoveBookmark(freelancer.profileId)} className="absolute top-6 right-6 p-2.5 bg-zinc-50 rounded-xl text-zinc-300 hover:text-red-500 transition-all"><Trash2 size={18} /></button>
+                                        <div className="flex items-center gap-6 mb-8 cursor-pointer" onClick={() => router.push(`/freelancer/${freelancer.profileId}`)}><div className="w-20 h-20 rounded-2xl bg-zinc-100 overflow-hidden border border-zinc-200 group-hover:border-[#FF7D00] transition-colors">{freelancer.profileImageUrl ? <img src={freelancer.profileImageUrl} alt="" className="w-full h-full object-cover" /> : <div className="w-full h-full flex items-center justify-center text-zinc-300"><User size={32} /></div>}</div><div><div className="flex items-center gap-2 mb-1"><h3 className="text-2xl font-black text-zinc-900 group-hover:text-[#FF7D00] transition-colors">{freelancer.userName}</h3><span className="px-2 py-0.5 bg-zinc-950 text-white text-[9px] font-black rounded font-mono">{freelancer.gradeName}</span></div><div className="flex items-center gap-1.5 text-xs font-bold text-[#FF7D00]"><Star size={14} fill="#FF7D00" /><span>{freelancer.averageRating.toFixed(1)}</span><span className="text-zinc-300 ml-1">({freelancer.reviewCount} Reviews)</span></div></div></div>
+                                        <p className="text-sm font-medium text-zinc-500 line-clamp-2 leading-relaxed h-10 italic">"{freelancer.introduction || "자기소개가 없습니다."}"</p>
+                                    </motion.div>
+                                ))}
+                            </div>
+                        )}
+                    </motion.div>
+                )}
+
+                {/* 3. 역제안 현황 섹션 */}
+                {activeMainTab === 'PROPOSALS' && (
+                    <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="space-y-8">
+                        <div className="flex items-center justify-between">
+                            <h2 className="text-xl font-black tracking-tight text-zinc-950 uppercase font-mono">
+                                보낸 제안 <span className="text-[#FF7D00] ml-1">[{sentProposals.length}]</span>
+                            </h2>
+                        </div>
+
+                        {proposalsLoading ? (
+                            <div className="py-24 flex justify-center"><Loader2 className="w-10 h-10 animate-spin text-[#FF7D00]" /></div>
+                        ) : sentProposals.length === 0 ? (
+                            <div className="bg-zinc-100/50 rounded-[2.5rem] border border-zinc-200 border-dashed p-16 flex flex-col items-center justify-center text-center">
+                                <Sparkles size={40} className="text-zinc-200 mb-4" />
+                                <p className="text-lg font-black text-zinc-500 mb-1 italic">NO_SENT_PROPOSALS_YET</p>
+                                <p className="text-sm font-medium text-zinc-400 leading-relaxed max-w-sm">관심 인재에게 협업을 지리게 요청해 보세요!</p>
+                            </div>
+                        ) : (
+                            <div className="grid grid-cols-1 gap-5">
+                                {sentProposals.map((proposal, idx) => (
+                                    <motion.div
+                                        initial={{ x: -20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} transition={{ delay: idx * 0.05 }}
+                                        key={proposal.proposalId}
+                                        className="bg-white p-8 rounded-[2rem] border border-zinc-100 hover:border-[#FF7D00] hover:shadow-xl transition-all group flex flex-col md:flex-row justify-between items-center gap-6"
+                                    >
+                                        <div className="flex-1">
+                                            <div className="flex items-center gap-3 mb-4">
+                                                <span className="bg-zinc-950 text-white px-2.5 py-0.5 rounded text-[9px] font-black uppercase font-mono">SENT_PROPOSAL</span>
+                                                <span className={`px-2.5 py-0.5 rounded text-[9px] font-black uppercase font-mono border ${
+                                                    proposal.status === 'ACCEPTED' ? 'bg-orange-50 text-[#FF7D00] border-orange-100' :
+                                                        proposal.status === 'REJECTED' ? 'bg-red-50 text-red-500 border-red-100' : 'bg-zinc-50 text-zinc-400 border-zinc-200'
+                                                }`}>
+                                                    {proposal.statusDescription}
+                                                </span>
                                             </div>
-
-                                            <div className="p-5 bg-white rounded-xl border border-zinc-100 text-lg font-medium text-zinc-600 leading-relaxed italic">
-                                                "{app.message || "지원 메시지가 없습니다."}"
-                                            </div>
-
-                                            <div className="flex justify-between items-center">
-                                                <div className="flex flex-wrap gap-2">
-                                                    {app.freelancerSkills?.slice(0, 3).map((skill: any) => (
-                                                        <span key={skill.skillId} className="px-3 py-1 bg-white border border-zinc-100 text-xs font-bold text-zinc-400 rounded-lg group-hover:border-[#FF7D00]/20 group-hover:text-[#FF7D00] transition-colors">
-                                                            #{skill.name}
-                                                        </span>
-                                                    ))}
-                                                </div>
-
-                                                {app.status === 'PENDING' ? (
-                                                    <div className="flex gap-3">
-                                                        <button
-                                                            onClick={() => handleApplicationStatus(app.applicationId, 'ACCEPTED')}
-                                                            className="px-8 py-3 bg-zinc-950 text-white rounded-xl text-sm font-black hover:bg-[#FF7D00] transition-all shadow-md"
-                                                        >
-                                                            수락
-                                                        </button>
-                                                        <button
-                                                            onClick={() => handleApplicationStatus(app.applicationId, 'REJECTED')}
-                                                            className="px-8 py-3 bg-white border border-zinc-200 text-zinc-400 rounded-xl text-sm font-black hover:text-red-600 hover:border-red-100 transition-all"
-                                                        >
-                                                            거절
-                                                        </button>
-                                                    </div>
-                                                ) : (
-                                                    <div className={`px-8 py-3 rounded-xl text-sm font-black ${app.status === 'ACCEPTED' ? 'bg-orange-50 text-[#FF7D00]' : 'bg-red-50 text-red-600'}`}>
-                                                        {app.status === 'ACCEPTED' ? '수락 완료' : '지원 거절됨'}
-                                                    </div>
-                                                )}
+                                            <h3 className="text-2xl font-black text-zinc-900 group-hover:text-[#FF7D00] transition-colors mb-2 tracking-tight">
+                                                To: {proposal.freelancerName}
+                                            </h3>
+                                            <p className="text-xs font-bold text-zinc-400 uppercase font-mono mb-6 flex items-center gap-2">
+                                                <Briefcase size={14} className="text-[#FF7D00]" /> Target_Project: {proposal.projectName}
+                                            </p>
+                                            <div className="p-4 bg-zinc-50 rounded-xl border border-zinc-100 text-sm font-medium text-zinc-500 leading-relaxed italic">
+                                                "{proposal.message || "보낸 메시지가 없습니다."}"
                                             </div>
                                         </div>
-                                    ))
-                                )}
+
+                                        <div className="w-full md:w-auto flex flex-row md:flex-col justify-between items-end gap-4 min-w-[200px]">
+                                            <div className="text-right">
+                                                <p className="text-[10px] font-black text-zinc-400 uppercase font-mono tracking-widest mb-1">Offered_Price</p>
+                                                <p className="text-2xl font-black text-zinc-900 font-mono italic">₩{proposal.offeredPrice.toLocaleString()}</p>
+                                            </div>
+                                            <div className="text-right">
+                                                <p className="text-[10px] font-black text-zinc-400 uppercase font-mono tracking-widest mb-1">Sent_At</p>
+                                                <p className="text-xs font-bold text-zinc-500 flex items-center justify-end gap-1">
+                                                    <Clock size={12} /> {new Date(proposal.createdAt).toLocaleDateString()}
+                                                </p>
+                                            </div>
+                                            <button
+                                                onClick={() => router.push(`/freelancer/${proposal.freelancerProfileId}`)}
+                                                className="w-full md:w-auto px-6 py-3 bg-zinc-50 text-zinc-400 hover:text-[#FF7D00] hover:bg-orange-50 rounded-xl text-[10px] font-black uppercase tracking-widest transition-all font-mono flex items-center justify-center gap-2"
+                                            >
+                                                View_Profile <ArrowUpRight size={14} />
+                                            </button>
+                                        </div>
+                                    </motion.div>
+                                ))}
                             </div>
-                        </motion.div>
-                    </div>
+                        )}
+                    </motion.div>
                 )}
-            </AnimatePresence>
+            </main>
         </div>
     );
 }

--- a/frontend/app/client/dashboard/page.tsx
+++ b/frontend/app/client/dashboard/page.tsx
@@ -1,34 +1,39 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import api from '@/app/lib/axios';
 import { NotificationBell } from '@/components/notifications/NotificationProvider';
 import {
     User, Users, CheckCircle, XCircle, Edit, Trash2,
     Calendar, DollarSign, Activity, ChevronRight,
-    Briefcase, Heart, Send, Sparkles, Star, MapPin, Globe, Loader2, Clock, ArrowUpRight, Plus
+    Briefcase, Heart, Send, Sparkles, Star, MapPin, Globe, Loader2, Clock, ArrowUpRight, Plus, RefreshCcw
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 export default function ClientDashboardPage() {
     const router = useRouter();
     const [projects, setProjects] = useState<any[]>([]);
-    const [bookmarks, setBookmarks] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
-    const [bookmarksLoading, setBookmarksLoading] = useState(false);
     const [authorized, setAuthorized] = useState(false);
+
+    // 찜 목록 관련 상태
+    const [bookmarks, setBookmarks] = useState<any[]>([]);
+    const [bookmarksLoading, setBookmarksLoading] = useState(false);
+    const [bookmarkPage, setBookmarkPage] = useState(0);
+    const [hasMoreBookmarks, setHasMoreBookmarks] = useState(true);
 
     const [activeMainTab, setActiveMainTab] = useState<'PROJECTS' | 'BOOKMARKS' | 'PROPOSALS'>('PROJECTS');
     const [filterStatus, setFilterStatus] = useState<string>('ALL');
 
-    // 🎯 [지원자 관리] 상태
+    // 지원자 관리 상태
     const [expandedProjectId, setExpandedProjectId] = useState<number | null>(null);
     const [applicantsByProject, setApplicantsByProject] = useState<{ [key: number]: any[] }>({});
     const [loadingApplicants, setLoadingApplicants] = useState<{ [key: number]: boolean }>({});
+    const [applicantsErrorByProject, setApplicantsErrorByProject] = useState<{ [key: number]: boolean }>({});
     const [selectedProjectForApplicant, setSelectedProjectForApplicant] = useState<any>(null);
 
-    // 🎯 [역제안 관리] 신규 상태
+    // 역제안 관리 상태
     const [sentProposals, setSentProposals] = useState<any[]>([]);
     const [proposalsLoading, setProposalsLoading] = useState(false);
 
@@ -58,7 +63,6 @@ export default function ClientDashboardPage() {
         checkAccess();
     }, [router]);
 
-    // 1. 운영 프로젝트 조회
     const fetchMyProjects = async () => {
         try {
             const { data } = await api.get('/v1/projects/me');
@@ -67,45 +71,49 @@ export default function ClientDashboardPage() {
         } catch (err) { console.error("로드 실패", err); } finally { setLoading(false); }
     };
 
-    // 2. 관심 인재 조회
-    const fetchBookmarks = async () => {
-        setBookmarksLoading(true);
+    const fetchBookmarks = useCallback(async (isLoadMore = false) => {
+        if (!isLoadMore) {
+            setBookmarksLoading(true);
+            setBookmarkPage(0);
+        }
+        const targetPage = isLoadMore ? bookmarkPage + 1 : 0;
         try {
-            const { data } = await api.get('/bookmarks/freelancers');
-            setBookmarks(data.content || []);
-        } catch (err) { console.error("찜 목록 로드 실패", err); } finally { setBookmarksLoading(false); }
-    };
+            const { data } = await api.get(`/bookmarks/freelancers?page=${targetPage}&size=9`);
+            const newContent = data.content || [];
+            setBookmarks(prev => isLoadMore ? [...prev, ...newContent] : newContent);
+            setBookmarkPage(targetPage);
+            setHasMoreBookmarks(!data.last);
+        } catch (err) {
+            console.error("찜 목록 로드 실패", err);
+        } finally {
+            setBookmarksLoading(false);
+        }
+    }, [bookmarkPage]);
 
-    // 3. 🔍 [NEW] 보낸 역제안 목록 조회
     const fetchSentProposals = async () => {
         setProposalsLoading(true);
         try {
             const { data } = await api.get('/v1/proposals/sent');
             setSentProposals(data || []);
-        } catch (err) {
-            console.error("제안 로드 실패", err);
-        } finally {
-            setProposalsLoading(false);
-        }
+        } catch (err) { console.error("제안 로드 실패", err); } finally { setProposalsLoading(false); }
     };
 
     const handleRemoveBookmark = async (profileId: number) => {
         if (!confirm("찜 목록에서 삭제하시겠습니까?")) return;
         try {
             await api.delete(`/bookmarks/freelancers/${profileId}`);
-            fetchBookmarks();
+            fetchBookmarks(false);
         } catch (err) { alert("삭제에 실패했습니다."); }
     };
 
     useEffect(() => {
         if (authorized) {
             if (activeMainTab === 'PROJECTS') fetchMyProjects();
-            if (activeMainTab === 'BOOKMARKS') fetchBookmarks();
-            if (activeMainTab === 'PROPOSALS') fetchSentProposals(); // 역제안 탭 활성화 시 호출
+            if (activeMainTab === 'BOOKMARKS') fetchBookmarks(false);
+            if (activeMainTab === 'PROPOSALS') fetchSentProposals();
         }
     }, [authorized, activeMainTab]);
 
-    // 기존 프로젝트 수정/삭제/지원자 핸들러 (유지)
     const handleEditProjectClick = (projectId: number) => router.push(`/client/projects/${projectId}/edit`);
     const handleStatusChange = async (projectId: number, action: 'start' | 'close') => {
         const msg = action === 'start' ? '시작' : '마감';
@@ -122,13 +130,17 @@ export default function ClientDashboardPage() {
         if (expandedProjectId === pid) { setExpandedProjectId(null); return; }
         setSelectedProjectForApplicant(project);
         setExpandedProjectId(pid);
-        if (applicantsByProject[pid]) return;
+        if (applicantsByProject[pid] && !applicantsErrorByProject[pid]) return;
         setLoadingApplicants(prev => ({ ...prev, [pid]: true }));
+        setApplicantsErrorByProject(prev => ({ ...prev, [pid]: false }));
         try {
             const { data } = await api.get(`/projects/${pid}/applications`);
             setApplicantsByProject(prev => ({ ...prev, [pid]: data }));
-        } catch (err) { setApplicantsByProject(prev => ({ ...prev, [pid]: [] })); }
-        finally { setLoadingApplicants(prev => ({ ...prev, [pid]: false })); }
+        } catch (err) {
+            setApplicantsErrorByProject(prev => ({ ...prev, [pid]: true }));
+        } finally {
+            setLoadingApplicants(prev => ({ ...prev, [pid]: false }));
+        }
     };
 
     const handleApplicationStatus = async (applicationId: number, status: 'ACCEPTED' | 'REJECTED') => {
@@ -144,136 +156,133 @@ export default function ClientDashboardPage() {
     };
 
     if (!authorized || loading) return (
-        <div className="flex min-h-screen items-center justify-center bg-zinc-50 text-[#FF7D00] font-black text-xl animate-pulse uppercase font-mono">
-            Checking_Authorization...
-        </div>
+        <div className="flex min-h-screen items-center justify-center bg-zinc-950 text-[#FF7D00] font-black text-xl animate-pulse uppercase font-mono">데이터를 불러오는 중...</div>
     );
 
     const filteredProjects = projects.filter(p => filterStatus === 'ALL' || p.status === filterStatus);
 
     return (
         <div className="min-h-screen bg-zinc-50 text-zinc-900 pb-20 relative overflow-hidden font-sans">
-            <div className="pointer-events-none fixed z-0 w-[300px] h-[300px] rounded-full bg-[#FF7D00]/20 blur-[120px] transition-all duration-200"
-                 style={{ left: cursor.x - 150, top: cursor.y - 150 }} />
+            {/* 배경 레이어 */}
+            <div className="fixed inset-0 pointer-events-none z-0">
+                <div className="absolute w-[500px] h-[500px] rounded-full bg-[#FF7D00]/10 blur-[120px] transition-all duration-300" style={{ left: cursor.x - 250, top: cursor.y - 250 }} />
+                <div className="absolute w-[400px] h-[400px] rounded-full bg-[#7A4FFF]/10 blur-[100px] transition-all duration-700" style={{ left: cursor.x - 100, top: cursor.y - 100 }} />
+                <div className="absolute inset-0 opacity-[0.05]" style={{ backgroundImage: 'radial-gradient(#000 0.5px, transparent 0.5px), linear-gradient(#000 0.5px, transparent 0.5px), linear-gradient(90deg, #000 0.5px, transparent 0.5px)', backgroundSize: '20px 20px, 100px 100px, 100px 100px' }} />
+            </div>
 
-            <nav className="w-full py-5 px-10 bg-white/80 backdrop-blur-xl border-b border-zinc-200 flex justify-between items-center sticky top-0 z-50 shadow-sm">
-                <div className="font-black text-2xl tracking-tighter cursor-pointer" onClick={() => router.push("/")}>
-                    <span className="text-[#FF7D00]">Dev</span><span className="text-[#7A4FFF]">Near</span>
+            <nav className="w-full py-6 px-10 bg-white/70 backdrop-blur-2xl border-b border-zinc-200/50 flex justify-between items-center sticky top-0 z-50 shadow-sm">
+                <div className="font-black text-2xl tracking-tighter cursor-pointer group" onClick={() => router.push("/")}>
+                    <span className="text-[#FF7D00] group-hover:drop-shadow-[0_0_8px_#FF7D00]">Dev</span><span className="text-[#7A4FFF]">Near</span>
                 </div>
-                <div className="flex gap-4 items-center relative z-10 md:gap-6">
-                    <button onClick={() => router.push('/client/mypage')} className="text-xs font-black text-zinc-500 hover:text-zinc-950 tracking-widest transition uppercase font-mono">MY_PAGE</button>
+                <div className="flex gap-4 items-center relative z-10 md:gap-8">
+                    <button onClick={() => router.push('/client/mypage')} className="text-xs font-black text-zinc-400 hover:text-zinc-950 tracking-[0.2em] transition uppercase font-mono">mypage</button>
                     <NotificationBell />
-                    <button onClick={() => router.push("/client/projects/new")} className="px-6 py-2.5 bg-[#FF7D00] text-white rounded-xl text-xs font-black tracking-widest hover:brightness-110 transition shadow-lg shadow-orange-100 uppercase font-mono">Register_Project</button>
+                    <button onClick={() => router.push("/client/projects/new")} className="px-7 py-3 bg-zinc-950 text-white rounded-2xl text-xs font-black tracking-widest hover:bg-[#FF7D00] transition-all shadow-xl flex items-center gap-2 uppercase font-mono"><Plus size={14} /> 프로젝트 등록</button>
                 </div>
             </nav>
 
-            <header className="relative pt-16 pb-12 px-8 bg-white border-b border-zinc-200 overflow-hidden">
-                <div className="max-w-5xl mx-auto relative z-10">
-                    <div className="flex items-center gap-2 mb-4">
-                        <span className="w-8 h-[2px] bg-[#FF7D00]"></span>
-                        <span className="text-[10px] font-black text-zinc-400 uppercase tracking-[0.3em] font-mono">Work_Hub</span>
-                    </div>
-                    <h1 className="text-4xl font-black tracking-tight mb-8">대시보드</h1>
+            <header className="relative pt-24 pb-16 px-8 overflow-hidden max-w-6xl mx-auto">
+                <motion.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} className="flex items-center gap-3 mb-6">
+                    <span className="w-12 h-[3px] bg-[#FF7D00] rounded-full"></span>
+                    <span className="text-[11px] font-black text-[#FF7D00] uppercase tracking-[0.4em] font-mono">관리 콘솔</span>
+                </motion.div>
+                <h1 className="text-5xl font-black tracking-tighter mb-12 text-zinc-950">클라이언트 <span className="text-zinc-400">대시보드</span></h1>
 
-                    <div className="flex gap-8 border-b border-zinc-100">
-                        {[
-                            { id: 'PROJECTS', label: '운영 프로젝트', icon: <Briefcase size={16} /> },
-                            { id: 'BOOKMARKS', label: '관심 인재', icon: <Heart size={16} /> },
-                            { id: 'PROPOSALS', label: '제안 현황', icon: <Send size={16} /> }
-                        ].map((tab) => (
-                            <button
-                                key={tab.id}
-                                onClick={() => setActiveMainTab(tab.id as any)}
-                                className={`flex items-center gap-2 pb-4 text-sm font-black transition-all relative ${
-                                    activeMainTab === tab.id ? 'text-[#FF7D00]' : 'text-zinc-400 hover:text-zinc-600'
-                                }`}
-                            >
-                                {tab.icon} {tab.label}
-                                {activeMainTab === tab.id && (
-                                    <motion.div layoutId="activeTab" className="absolute bottom-0 left-0 right-0 h-1 bg-[#FF7D00] rounded-t-full" />
-                                )}
-                            </button>
-                        ))}
-                    </div>
+                <div className="flex gap-10 border-b border-zinc-200/50">
+                    {[
+                        { id: 'PROJECTS', label: '프로젝트 관리', icon: <Briefcase size={18} /> },
+                        { id: 'BOOKMARKS', label: '관심 프리랜서', icon: <Heart size={18} /> },
+                        { id: 'PROPOSALS', label: '제안 현황', icon: <Send size={18} /> }
+                    ].map((tab) => (
+                        <button key={tab.id} onClick={() => setActiveMainTab(tab.id as any)} className={`flex items-center gap-2.5 pb-6 text-sm font-black transition-all relative ${activeMainTab === tab.id ? 'text-[#FF7D00]' : 'text-zinc-400 hover:text-zinc-600'}`}>
+                            {tab.icon} {tab.label}
+                            {activeMainTab === tab.id && <motion.div layoutId="activeTabIndicator" className="absolute bottom-0 left-0 right-0 h-1 bg-[#FF7D00] rounded-t-full shadow-[0_-4px_10px_#FF7D00]" />}
+                        </button>
+                    ))}
                 </div>
             </header>
 
-            <main className="max-w-5xl mx-auto px-8 py-12 relative z-10">
+            <main className="max-w-6xl mx-auto px-8 py-16 relative z-10">
                 {/* 1. 운영 프로젝트 섹션 */}
                 {activeMainTab === 'PROJECTS' && (
-                    <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
-                        <div className="flex flex-col md:flex-row md:items-center justify-between mb-10 gap-6">
-                            {/* 🔍 [수정 포인트] 제목 옆에 등록 버튼 추가 */}
+                    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+                        <div className="flex flex-col lg:flex-row lg:items-end justify-between mb-12 gap-8">
                             <div className="flex items-center gap-4">
-                                <h2 className="text-xl font-black tracking-tight text-zinc-950 uppercase font-mono">내 프로젝트 <span className="text-[#FF7D00] ml-1">[{filteredProjects.length}]</span></h2>
-                                <button
-                                    onClick={() => router.push("/client/projects/new")}
-                                    className="p-2 bg-[#FF7D00]/10 text-[#FF7D00] rounded-full hover:bg-[#FF7D00] hover:text-white transition-all shadow-sm"
-                                    title="새 프로젝트 등록"
-                                >
-                                    <Plus size={20} strokeWidth={3} />
-                                </button>
+                                <h2 className="text-2xl font-black tracking-tight text-zinc-950 uppercase font-mono">프로젝트 목록</h2>
+                                <span className="px-3 py-1 bg-white border border-zinc-200 rounded-lg text-xs font-black text-[#FF7D00]">총 {filteredProjects.length}개</span>
+                                <button onClick={() => router.push("/client/projects/new")} className="p-2.5 bg-white border border-zinc-200 text-[#FF7D00] rounded-xl hover:bg-[#FF7D00] hover:text-white transition-all shadow-sm group"><Plus size={20} className="group-hover:rotate-90 transition-transform duration-300" strokeWidth={3} /></button>
                             </div>
-
-                            <div className="flex gap-1.5 p-1.5 bg-white border border-zinc-200 rounded-2xl shadow-sm">
+                            <div className="flex gap-2 p-2 bg-white/50 backdrop-blur-md border border-zinc-200 rounded-3xl">
                                 {[{ id: 'ALL', label: '전체' }, { id: 'OPEN', label: '모집중' }, { id: 'IN_PROGRESS', label: '진행중' }, { id: 'CLOSED', label: '마감됨' }].map((s) => (
-                                    <button key={s.id} onClick={() => setFilterStatus(s.id)} className={`px-5 py-2 rounded-xl text-[10px] font-black transition-all tracking-widest uppercase font-mono ${filterStatus === s.id ? 'bg-zinc-950 text-white shadow-md' : 'text-zinc-400 hover:text-zinc-600'}`}>{s.label}</button>
+                                    <button key={s.id} onClick={() => setFilterStatus(s.id)} className={`px-6 py-2.5 rounded-2xl text-xs font-black transition-all tracking-wider uppercase font-mono ${filterStatus === s.id ? 'bg-zinc-950 text-white shadow-xl' : 'text-zinc-400 hover:text-zinc-600'}`}>{s.label}</button>
                                 ))}
                             </div>
                         </div>
-                        <div className="grid gap-6">
+
+                        <div className="grid gap-8">
                             {filteredProjects.map((project, idx) => {
                                 const isExpanded = expandedProjectId === project.projectId;
                                 const projectApplicants = applicantsByProject[project.projectId] || [];
+                                const hasError = applicantsErrorByProject[project.projectId];
+
                                 return (
-                                    <div key={project.projectId} className="flex flex-col gap-2">
-                                        <div className={`group bg-white p-8 rounded-[2rem] border transition-all ${isExpanded ? 'border-[#FF7D00] shadow-xl ring-1 ring-[#FF7D00]' : 'border-zinc-100 shadow-sm hover:border-[#FF7D00]'}`}>
-                                            <div className="flex flex-col md:flex-row justify-between items-center w-full">
+                                    <div key={project.projectId} className="flex flex-col gap-3">
+                                        <motion.div className={`group bg-white p-10 rounded-[2.5rem] border transition-all duration-500 ${isExpanded ? 'border-[#FF7D00] shadow-2xl ring-1 ring-[#FF7D00]/20' : 'border-zinc-100 shadow-xl hover:border-[#FF7D00]/30'}`}>
+                                            <div className="flex flex-col xl:flex-row justify-between items-center gap-8 w-full">
                                                 <div className="flex-1 w-full">
-                                                    <span className={`px-3 py-1 rounded-md text-[10px] font-black tracking-widest uppercase font-mono border ${project.status === 'OPEN' ? 'bg-[#FF7D00]/10 text-[#FF7D00] border-[#FF7D00]/20' : 'bg-zinc-100 text-zinc-500'}`}>{project.status}</span>
-                                                    <h3 className="text-2xl font-black text-zinc-900 mt-4 group-hover:text-[#FF7D00] transition-colors tracking-tight">{project.projectName}</h3>
-                                                    <div className="flex gap-6 mt-4 text-xs font-bold text-zinc-400 font-mono uppercase">
-                                                        <span><DollarSign size={14} className="inline mr-1 text-[#FF7D00]"/>{project.budget?.toLocaleString()}원</span>
-                                                        <span><Calendar size={14} className="inline mr-1 text-[#FF7D00]"/>{project.deadline} 마감</span>
+                                                    <span className={`px-4 py-1.5 rounded-full text-[10px] font-black tracking-[0.2em] uppercase font-mono border ${project.status === 'OPEN' ? 'bg-[#FF7D00]/10 text-[#FF7D00] border-[#FF7D00]/20' : 'bg-zinc-50 text-zinc-400'}`}>{project.status === 'OPEN' ? '모집중' : '진행/마감'}</span>
+                                                    <h3 className="text-3xl font-black text-zinc-900 mt-4 group-hover:text-[#FF7D00] transition-colors tracking-tight">{project.projectName}</h3>
+                                                    <div className="flex gap-8 mt-6 text-xs font-bold text-zinc-400 font-mono uppercase">
+                                                        <span><DollarSign size={16} className="inline mr-1 text-[#FF7D00]"/>{project.budget?.toLocaleString()}원</span>
+                                                        <span><Calendar size={16} className="inline mr-1 text-[#FF7D00]"/>{project.deadline} 마감</span>
                                                     </div>
                                                 </div>
-                                                <div className="flex items-center gap-4 mt-8 md:mt-0">
-                                                    <div className="flex gap-1 px-3 border-x border-zinc-100">
-                                                        <button onClick={() => handleEditProjectClick(project.projectId)} className="p-3 text-zinc-300 hover:text-[#7A4FFF] transition-all"><Edit size={18} /></button>
-                                                        <button onClick={() => handleDeleteProject(project.projectId)} className="p-3 text-zinc-300 hover:text-red-500 transition-all"><Trash2 size={18} /></button>
+                                                <div className="flex items-center gap-5">
+                                                    <div className="flex gap-2 px-4 border-x border-zinc-100">
+                                                        <button onClick={() => handleEditProjectClick(project.projectId)} className="p-4 text-zinc-300 hover:text-[#7A4FFF] transition-all"><Edit size={20} /></button>
+                                                        <button onClick={() => handleDeleteProject(project.projectId)} className="p-4 text-zinc-300 hover:text-red-500 transition-all"><Trash2 size={20} /></button>
                                                     </div>
-                                                    <button onClick={() => handleViewApplicants(project)} className={`px-8 py-4 rounded-xl font-black text-xs tracking-widest uppercase transition-all flex items-center gap-2 ${isExpanded ? 'bg-[#FF7D00] text-white shadow-orange-200' : 'bg-zinc-950 text-white shadow-zinc-200 hover:bg-[#FF7D00]'}`}>
-                                                        <Users size={16} /> Applicants {projectApplicants.length > 0 && `[${projectApplicants.length}]`}
+                                                    <button onClick={() => handleViewApplicants(project)} className={`px-10 py-5 rounded-[1.5rem] font-black text-xs tracking-[0.2em] uppercase transition-all flex items-center gap-3 shadow-2xl font-mono ${isExpanded ? 'bg-[#FF7D00] text-white shadow-orange-200' : 'bg-zinc-950 text-white hover:bg-[#FF7D00]'}`}>
+                                                        <Users size={18} /> 지원자 확인 {projectApplicants.length > 0 && `(${projectApplicants.length})`}
                                                     </button>
                                                 </div>
                                             </div>
-                                        </div>
-                                        {/* 지원자 리스트 인라인 확장 */}
+                                        </motion.div>
+
                                         <AnimatePresence>
                                             {isExpanded && (
                                                 <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: "auto", opacity: 1 }} exit={{ height: 0, opacity: 0 }} className="overflow-hidden">
-                                                    <div className="mt-2 mb-10 p-2 bg-zinc-100/50 rounded-[2rem] border border-zinc-200/50">
+                                                    <div className="mt-2 mb-12 p-3 bg-white border border-zinc-200 shadow-2xl rounded-[3rem]">
                                                         {loadingApplicants[project.projectId] ? (
-                                                            <div className="py-16 flex flex-col items-center justify-center gap-4 text-zinc-400 font-mono font-bold"><Loader2 className="w-8 h-8 animate-spin text-[#FF7D00]" /><span className="animate-pulse tracking-widest text-xs uppercase">Syncing_Applicants...</span></div>
+                                                            <div className="py-24 flex flex-col items-center justify-center gap-5"><Loader2 className="w-10 h-10 animate-spin text-[#FF7D00]" /><span className="animate-pulse tracking-[0.3em] text-xs font-black font-mono text-zinc-400 uppercase">지원자 정보를 동기화 중...</span></div>
+                                                        ) : hasError ? (
+                                                            <div className="py-24 flex flex-col items-center justify-center gap-4 text-center">
+                                                                <XCircle className="text-red-400 w-12 h-12" />
+                                                                <p className="text-lg font-black text-zinc-900 uppercase font-mono">연결 실패</p>
+                                                                <p className="text-sm font-medium text-zinc-400 mb-4">지원자 목록을 가져오는 데 실패했습니다.</p>
+                                                                {/* 🎯 [FIX] pid -> project.projectId 로 수정하여 에러 해결 */}
+                                                                <button onClick={() => { setApplicantsErrorByProject(p => ({ ...p, [project.projectId]: false })); handleViewApplicants(project); }} className="px-8 py-3 bg-zinc-950 text-white rounded-xl text-xs font-black flex items-center gap-2 hover:bg-[#FF7D00] transition-all uppercase font-mono"><RefreshCcw size={14} /> 다시 시도</button>
+                                                            </div>
                                                         ) : projectApplicants.length === 0 ? (
-                                                            <div className="py-16 text-center text-zinc-300 font-black border-2 border-dashed border-zinc-200 rounded-[1.5rem] text-xl font-mono uppercase bg-white">No_Applicants_Yet</div>
+                                                            <div className="py-24 text-center text-zinc-200 font-black border-4 border-dashed border-zinc-50 rounded-[2.5rem] text-2xl font-mono uppercase">지원자가 없습니다</div>
                                                         ) : (
-                                                            <div className="space-y-3 p-4">
+                                                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-5">
                                                                 {projectApplicants.map((app: any) => (
-                                                                    <div key={app.applicationId} className={`p-6 bg-white rounded-2xl border transition-all flex flex-col md:flex-row gap-6 items-center hover:shadow-md ${app.status === 'ACCEPTED' ? 'border-[#FF7D00] shadow-md shadow-orange-50' : 'border-zinc-100'}`}>
-                                                                        <div className="flex items-center gap-5 flex-1">
-                                                                            <div className="w-14 h-14 rounded-xl bg-zinc-50 border border-zinc-100 overflow-hidden cursor-pointer" onClick={() => router.push(`/freelancer/${app.freelancerId}`)}>{app.freelancerProfileImageUrl ? <img src={app.freelancerProfileImageUrl} alt="" className="w-full h-full object-cover" /> : <div className="w-full h-full flex items-center justify-center text-zinc-300"><User size={24} /></div>}</div>
+                                                                    <div key={app.applicationId} className={`p-8 bg-zinc-50 rounded-[2rem] border transition-all hover:bg-white hover:shadow-xl ${app.status === 'ACCEPTED' ? 'border-[#FF7D00] bg-orange-50/30' : 'border-zinc-100'}`}>
+                                                                        <div className="flex items-center gap-6 mb-8">
+                                                                            <div className="w-16 h-16 rounded-2xl bg-white border border-zinc-200 overflow-hidden cursor-pointer shadow-sm" onClick={() => router.push(`/freelancer/${app.freelancerId}`)}>{app.freelancerProfileImageUrl ? <img src={app.freelancerProfileImageUrl} alt="" className="w-full h-full object-cover" /> : <div className="w-full h-full flex items-center justify-center text-zinc-300"><User size={28} /></div>}</div>
                                                                             <div className="flex-1">
-                                                                                <div className="flex items-center gap-2 mb-1"><h4 className="font-black text-lg text-zinc-900">{app.freelancerNickname}</h4><span className="text-[10px] font-black text-[#FF7D00] bg-orange-50 px-2 py-0.5 rounded border border-orange-100 uppercase">매칭 {Math.round(app.matchingRate)}%</span></div>
+                                                                                <div className="flex items-center gap-3 mb-1"><h4 className="font-black text-xl text-zinc-900">{app.freelancerNickname}</h4><span className="text-[10px] font-black text-[#FF7D00] bg-white px-2 py-0.5 rounded border border-orange-100">일치율 {Math.round(app.matchingRate)}%</span></div>
+                                                                                <p className="text-[10px] font-black text-zinc-400 font-mono uppercase tracking-widest">프리랜서 노드</p>
                                                                             </div>
                                                                         </div>
-                                                                        <div className="flex items-center gap-8 w-full md:w-auto">
-                                                                            <div className="text-right"><p className="text-xl font-black text-zinc-900 font-mono">₩{(app.bidPrice || 0).toLocaleString()}</p><p className="text-[10px] font-bold text-zinc-300 uppercase font-mono">{app.status}</p></div>
-                                                                            <div className="flex gap-2 min-w-[140px] justify-end">
+                                                                        <div className="flex items-center justify-between pt-6 border-t border-zinc-200/50">
+                                                                            <p className="text-xl font-black text-zinc-950 font-mono italic">₩{app.bidPrice?.toLocaleString()}</p>
+                                                                            <div className="flex gap-2">
                                                                                 {app.status === 'PENDING' ? (
-                                                                                    <><button onClick={() => handleApplicationStatus(app.applicationId, 'ACCEPTED')} className="px-5 py-2.5 bg-zinc-950 text-white rounded-xl text-[10px] font-black hover:bg-[#FF7D00] transition-all uppercase font-mono">수락</button><button onClick={() => handleApplicationStatus(app.applicationId, 'REJECTED')} className="px-5 py-2.5 bg-white border border-zinc-200 text-zinc-400 rounded-xl text-[10px] font-black hover:text-red-500 hover:border-red-200 transition-all uppercase font-mono">거절</button></>
+                                                                                    <><button onClick={() => handleApplicationStatus(app.applicationId, 'ACCEPTED')} className="px-6 py-3 bg-zinc-950 text-white rounded-xl text-[10px] font-black hover:bg-[#FF7D00] transition-all uppercase">수락</button><button onClick={() => handleApplicationStatus(app.applicationId, 'REJECTED')} className="px-6 py-3 bg-white border border-zinc-200 text-zinc-400 rounded-xl text-[10px] font-black hover:text-red-500 transition-all uppercase">거절</button></>
                                                                                 ) : (
-                                                                                    <div className={`px-5 py-2.5 rounded-xl text-[10px] font-black flex items-center gap-2 uppercase font-mono ${app.status === 'ACCEPTED' ? 'bg-orange-50 text-[#FF7D00] border border-orange-100' : 'bg-red-50 text-red-500 border border-red-100'}`}>{app.status === 'ACCEPTED' ? <CheckCircle size={14} /> : <XCircle size={14} />}{app.status}</div>
+                                                                                    <div className={`px-6 py-3 rounded-xl text-[10px] font-black flex items-center gap-2 uppercase border ${app.status === 'ACCEPTED' ? 'bg-orange-50 text-[#FF7D00] border-orange-100' : 'bg-red-50 text-red-500 border border-red-100'}`}>{app.status === 'ACCEPTED' ? <CheckCircle size={14} /> : <XCircle size={14} />}{app.status === 'ACCEPTED' ? '수락됨' : '거절됨'}</div>
                                                                                 )}
                                                                             </div>
                                                                         </div>
@@ -294,17 +303,44 @@ export default function ClientDashboardPage() {
 
                 {/* 2. 관심 인재 섹션 */}
                 {activeMainTab === 'BOOKMARKS' && (
-                    <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="space-y-8">
-                        <div className="flex items-center justify-between"><h2 className="text-xl font-black tracking-tight text-zinc-950 uppercase font-mono">관심 인재 <span className="text-[#FF7D00] ml-1">[{bookmarks.length}]</span></h2></div>
-                        {bookmarksLoading ? ( <div className="py-24 flex justify-center"><Loader2 className="w-10 h-10 animate-spin text-[#FF7D00]" /></div> ) : bookmarks.length === 0 ? ( <div className="text-center py-32 bg-white rounded-[2.5rem] border-2 border-dashed border-zinc-100 font-black text-zinc-200 italic uppercase tracking-tighter">Null: No_Bookmarked_Talents</div> ) : (
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <motion.div initial={{ opacity: 0, scale: 0.98 }} animate={{ opacity: 1, scale: 1 }} className="space-y-12">
+                        <div className="flex items-center justify-between mb-4">
+                            <div><h2 className="text-3xl font-black tracking-tight text-zinc-950 uppercase font-mono mb-2">관심 프리랜서</h2><p className="text-sm font-medium text-zinc-400">지목한 최정상급 프리랜서 후보군입니다.</p></div>
+                            <span className="px-5 py-2 bg-white border border-zinc-200 rounded-2xl text-xs font-black text-[#FF7D00]">프리랜서 수: {bookmarks.length}명</span>
+                        </div>
+                        {bookmarks.length === 0 && !bookmarksLoading ? (
+                            <div className="text-center py-48 bg-white/40 backdrop-blur-sm rounded-[3rem] border-2 border-dashed border-zinc-200 font-black text-zinc-200 italic uppercase tracking-tighter">찜한 인재가 없습니다</div>
+                        ) : (
+                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                                 {bookmarks.map((freelancer, idx) => (
-                                    <motion.div initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} transition={{ delay: idx * 0.05 }} key={freelancer.profileId} className="group bg-white p-8 rounded-3xl border border-zinc-100 hover:border-[#FF7D00] hover:shadow-2xl transition-all relative">
-                                        <button onClick={() => handleRemoveBookmark(freelancer.profileId)} className="absolute top-6 right-6 p-2.5 bg-zinc-50 rounded-xl text-zinc-300 hover:text-red-500 transition-all"><Trash2 size={18} /></button>
-                                        <div className="flex items-center gap-6 mb-8 cursor-pointer" onClick={() => router.push(`/freelancer/${freelancer.profileId}`)}><div className="w-20 h-20 rounded-2xl bg-zinc-100 overflow-hidden border border-zinc-200 group-hover:border-[#FF7D00] transition-colors">{freelancer.profileImageUrl ? <img src={freelancer.profileImageUrl} alt="" className="w-full h-full object-cover" /> : <div className="w-full h-full flex items-center justify-center text-zinc-300"><User size={32} /></div>}</div><div><div className="flex items-center gap-2 mb-1"><h3 className="text-2xl font-black text-zinc-900 group-hover:text-[#FF7D00] transition-colors">{freelancer.userName}</h3><span className="px-2 py-0.5 bg-zinc-950 text-white text-[9px] font-black rounded font-mono">{freelancer.gradeName}</span></div><div className="flex items-center gap-1.5 text-xs font-bold text-[#FF7D00]"><Star size={14} fill="#FF7D00" /><span>{freelancer.averageRating.toFixed(1)}</span><span className="text-zinc-300 ml-1">({freelancer.reviewCount} Reviews)</span></div></div></div>
-                                        <p className="text-sm font-medium text-zinc-500 line-clamp-2 leading-relaxed h-10 italic">"{freelancer.introduction || "자기소개가 없습니다."}"</p>
+                                    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: idx * 0.05 }} key={freelancer.profileId} className="group bg-white p-10 rounded-[3rem] border border-zinc-100 hover:border-[#FF7D00] hover:shadow-[0_20px_50px_rgba(255,125,0,0.15)] transition-all relative">
+                                        <button onClick={() => handleRemoveBookmark(freelancer.profileId)} className="absolute top-8 right-8 p-3 bg-zinc-50 rounded-2xl text-zinc-300 hover:text-red-500 hover:bg-red-50 transition-all"><Trash2 size={18} /></button>
+                                        <div className="flex flex-col items-center text-center mb-8 cursor-pointer" onClick={() => router.push(`/freelancer/${freelancer.profileId}`)}>
+                                            <div className="w-24 h-24 rounded-[2rem] bg-zinc-100 overflow-hidden border-4 border-white shadow-xl mb-6">{freelancer.profileImageUrl ? <img src={freelancer.profileImageUrl} alt="" className="w-full h-full object-cover" /> : <div className="w-full h-full flex items-center justify-center text-zinc-300 bg-zinc-50"><User size={40} /></div>}</div>
+                                            <div className="flex items-center gap-2 mb-2"><h3 className="text-2xl font-black text-zinc-900 group-hover:text-[#FF7D00] transition-colors">{freelancer.userName}</h3><span className="px-2 py-0.5 bg-zinc-950 text-white text-[9px] font-black rounded font-mono uppercase">{freelancer.gradeName}</span></div>
+                                            <div className="flex items-center gap-1.5 text-xs font-bold text-[#FF7D00] mb-4">
+                                                <Star size={16} fill="#FF7D00" strokeWidth={0} />
+                                                <span>{(freelancer.averageRating ?? 0).toFixed(1)}</span>
+                                                <span className="text-zinc-300 ml-1 font-mono">({freelancer.reviewCount} 리뷰)</span>
+                                            </div>
+                                            <p className="text-xs font-medium text-zinc-400 line-clamp-2 italic leading-relaxed">"{freelancer.introduction || "준비된 프리랜서입니다."}"</p>
+                                        </div>
+                                        <button onClick={() => router.push(`/freelancer/${freelancer.profileId}`)} className="w-full py-4 bg-zinc-50 text-zinc-400 group-hover:bg-[#FF7D00] group-hover:text-white rounded-[1.5rem] text-[10px] font-black uppercase tracking-widest transition-all font-mono">프로필 상세보기</button>
                                     </motion.div>
                                 ))}
+                            </div>
+                        )}
+
+                        {hasMoreBookmarks && (
+                            <div className="flex justify-center pt-10">
+                                <button
+                                    onClick={() => fetchBookmarks(true)}
+                                    disabled={bookmarksLoading}
+                                    className="px-12 py-5 bg-white border-2 border-zinc-900 text-zinc-900 rounded-[2rem] font-black text-xs tracking-[0.3em] uppercase hover:bg-zinc-900 hover:text-white transition-all flex items-center gap-4 disabled:opacity-50 disabled:cursor-not-allowed"
+                                >
+                                    {bookmarksLoading ? <Loader2 className="animate-spin" size={16} /> : <Plus size={16} />}
+                                    인재 더 보기
+                                </button>
                             </div>
                         )}
                     </motion.div>
@@ -312,67 +348,34 @@ export default function ClientDashboardPage() {
 
                 {/* 3. 역제안 현황 섹션 */}
                 {activeMainTab === 'PROPOSALS' && (
-                    <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="space-y-8">
+                    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-12">
                         <div className="flex items-center justify-between">
-                            <h2 className="text-xl font-black tracking-tight text-zinc-950 uppercase font-mono">
-                                보낸 제안 <span className="text-[#FF7D00] ml-1">[{sentProposals.length}]</span>
-                            </h2>
+                            <div><h2 className="text-3xl font-black tracking-tight text-zinc-950 uppercase font-mono mb-2">보낸 제안내역</h2><p className="text-sm font-medium text-zinc-400">먼저 협업을 제안한 인재 목록입니다.</p></div>
+                            <span className="px-5 py-2 bg-white border border-zinc-200 rounded-2xl text-xs font-black text-[#FF7D00]">총 {sentProposals.length}건</span>
                         </div>
-
-                        {proposalsLoading ? (
-                            <div className="py-24 flex justify-center"><Loader2 className="w-10 h-10 animate-spin text-[#FF7D00]" /></div>
-                        ) : sentProposals.length === 0 ? (
-                            <div className="bg-zinc-100/50 rounded-[2.5rem] border border-zinc-200 border-dashed p-16 flex flex-col items-center justify-center text-center">
-                                <Sparkles size={40} className="text-zinc-200 mb-4" />
-                                <p className="text-lg font-black text-zinc-500 mb-1 italic">NO_SENT_PROPOSALS_YET</p>
-                                <p className="text-sm font-medium text-zinc-400 leading-relaxed max-w-sm">관심 인재에게 협업을 지리게 요청해 보세요!</p>
+                        {proposalsLoading ? ( <div className="py-40 flex justify-center"><Loader2 className="w-12 h-12 animate-spin text-[#FF7D00]" /></div> ) : sentProposals.length === 0 ? (
+                            <div className="bg-white/40 backdrop-blur-sm rounded-[3rem] border-2 border-dashed border-zinc-200 p-24 flex flex-col items-center justify-center text-center">
+                                <Sparkles size={60} className="text-zinc-200 mb-6" strokeWidth={1} />
+                                <p className="text-xl font-black text-zinc-400 mb-2 italic">보낸 제안이 없습니다</p>
+                                <p className="text-sm font-medium text-zinc-300 max-w-sm">관심 인재에게 먼저 비즈니스 역제안을 날려보세요!</p>
                             </div>
                         ) : (
-                            <div className="grid grid-cols-1 gap-5">
+                            <div className="grid grid-cols-1 gap-6">
                                 {sentProposals.map((proposal, idx) => (
-                                    <motion.div
-                                        initial={{ x: -20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} transition={{ delay: idx * 0.05 }}
-                                        key={proposal.proposalId}
-                                        className="bg-white p-8 rounded-[2rem] border border-zinc-100 hover:border-[#FF7D00] hover:shadow-xl transition-all group flex flex-col md:flex-row justify-between items-center gap-6"
-                                    >
-                                        <div className="flex-1">
-                                            <div className="flex items-center gap-3 mb-4">
-                                                <span className="bg-zinc-950 text-white px-2.5 py-0.5 rounded text-[9px] font-black uppercase font-mono">SENT_PROPOSAL</span>
-                                                <span className={`px-2.5 py-0.5 rounded text-[9px] font-black uppercase font-mono border ${
-                                                    proposal.status === 'ACCEPTED' ? 'bg-orange-50 text-[#FF7D00] border-orange-100' :
-                                                        proposal.status === 'REJECTED' ? 'bg-red-50 text-red-500 border-red-100' : 'bg-zinc-50 text-zinc-400 border-zinc-200'
-                                                }`}>
-                                                    {proposal.statusDescription}
-                                                </span>
+                                    <motion.div initial={{ x: -20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} transition={{ delay: idx * 0.05 }} key={proposal.proposalId} className="bg-white p-10 rounded-[3rem] border border-zinc-100 hover:border-[#FF7D00] hover:shadow-2xl transition-all group flex flex-col xl:flex-row justify-between items-center gap-10">
+                                        <div className="flex-1 w-full">
+                                            <div className="flex items-center gap-3 mb-6">
+                                                <div className="flex items-center gap-2 bg-zinc-950 text-white px-3 py-1 rounded text-[9px] font-black uppercase font-mono tracking-widest"><Send size={10} /> 보낸 제안</div>
+                                                <span className={`px-3 py-1 rounded text-[9px] font-black uppercase font-mono border ${proposal.status === 'ACCEPTED' ? 'bg-orange-50 text-[#FF7D00] border-orange-100' : 'bg-zinc-50 text-zinc-400'}`}>{proposal.statusDescription}</span>
                                             </div>
-                                            <h3 className="text-2xl font-black text-zinc-900 group-hover:text-[#FF7D00] transition-colors mb-2 tracking-tight">
-                                                To: {proposal.freelancerName}
-                                            </h3>
-                                            <p className="text-xs font-bold text-zinc-400 uppercase font-mono mb-6 flex items-center gap-2">
-                                                <Briefcase size={14} className="text-[#FF7D00]" /> Target_Project: {proposal.projectName}
-                                            </p>
-                                            <div className="p-4 bg-zinc-50 rounded-xl border border-zinc-100 text-sm font-medium text-zinc-500 leading-relaxed italic">
-                                                "{proposal.message || "보낸 메시지가 없습니다."}"
-                                            </div>
+                                            <h3 className="text-3xl font-black text-zinc-900 group-hover:text-[#FF7D00] transition-colors mb-4">대상: {proposal.freelancerName}</h3>
+                                            <div className="flex items-center gap-2 mb-6"><div className="w-1.5 h-1.5 rounded-full bg-[#FF7D00]" /><p className="text-xs font-black text-zinc-400 uppercase font-mono tracking-widest">대상 프로젝트: {proposal.projectName}</p></div>
+                                            <div className="p-6 bg-zinc-50/50 rounded-2xl border border-zinc-100 text-sm font-medium text-zinc-500 italic leading-relaxed">"{proposal.message || "보낸 메시지가 없습니다."}"</div>
                                         </div>
-
-                                        <div className="w-full md:w-auto flex flex-row md:flex-col justify-between items-end gap-4 min-w-[200px]">
-                                            <div className="text-right">
-                                                <p className="text-[10px] font-black text-zinc-400 uppercase font-mono tracking-widest mb-1">Offered_Price</p>
-                                                <p className="text-2xl font-black text-zinc-900 font-mono italic">₩{proposal.offeredPrice.toLocaleString()}</p>
-                                            </div>
-                                            <div className="text-right">
-                                                <p className="text-[10px] font-black text-zinc-400 uppercase font-mono tracking-widest mb-1">Sent_At</p>
-                                                <p className="text-xs font-bold text-zinc-500 flex items-center justify-end gap-1">
-                                                    <Clock size={12} /> {new Date(proposal.createdAt).toLocaleDateString()}
-                                                </p>
-                                            </div>
-                                            <button
-                                                onClick={() => router.push(`/freelancer/${proposal.freelancerProfileId}`)}
-                                                className="w-full md:w-auto px-6 py-3 bg-zinc-50 text-zinc-400 hover:text-[#FF7D00] hover:bg-orange-50 rounded-xl text-[10px] font-black uppercase tracking-widest transition-all font-mono flex items-center justify-center gap-2"
-                                            >
-                                                View_Profile <ArrowUpRight size={14} />
-                                            </button>
+                                        <div className="w-full xl:w-auto flex flex-row xl:flex-col justify-between items-end gap-6 min-w-[240px] p-8 bg-zinc-50 rounded-[2rem] border border-zinc-100 shadow-inner">
+                                            <div className="text-right"><p className="text-[10px] font-black text-zinc-400 uppercase font-mono tracking-widest mb-1">제안 금액</p><p className="text-3xl font-black text-zinc-950 font-mono italic">₩{proposal.offeredPrice?.toLocaleString()}</p></div>
+                                            <div className="text-right"><p className="text-xs font-bold text-zinc-500 flex items-center justify-end gap-1 font-mono"><Clock size={14} /> {new Date(proposal.createdAt).toLocaleDateString()}</p></div>
+                                            <button onClick={() => router.push(`/freelancer/${proposal.freelancerProfileId}`)} className="w-full px-8 py-4 bg-white border border-zinc-200 text-zinc-400 hover:text-[#FF7D00] hover:border-[#FF7D00] rounded-xl text-[10px] font-black uppercase tracking-widest transition-all font-mono flex items-center justify-center gap-2 shadow-sm">프로필 분석 <ArrowUpRight size={16} /></button>
                                         </div>
                                     </motion.div>
                                 ))}

--- a/frontend/app/client/mypage/page.tsx
+++ b/frontend/app/client/mypage/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { Briefcase, User, Settings, LogOut, ChevronRight, Calendar, XCircle, ExternalLink, Heart, Send, Sparkles } from 'lucide-react';
+import { User, Settings, LogOut, ChevronRight, Calendar, XCircle, ExternalLink } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { notifyAuthChanged } from '../../lib/authEvents';
 import { NotificationBell } from '@/components/notifications/NotificationProvider';
@@ -10,7 +10,6 @@ import api from '../../lib/axios';
 
 import ProfileEditModal from '@/components/client_mypage/page';
 import CompanyEditModal from '@/components/client_mypage/CompanyEditModal';
-import BookmarkedFreelancers from '@/components/client_mypage/BookmarkedFreelancers';
 
 interface UserProfile {
     name: string;
@@ -121,27 +120,7 @@ export default function ClientMyPage() {
                 </div>
             </section>
 
-            <main className="max-w-6xl mx-auto px-10 py-16 relative z-10 space-y-16">
-                {/* 프리랜서 관리 섹션 */}
-                <section className="grid grid-cols-1 lg:grid-cols-2 gap-10">
-                    <div className="space-y-6">
-                        <h3 className="text-sm font-black uppercase font-mono tracking-[0.2em] text-zinc-400 flex items-center gap-2">
-                            <Heart className="w-4 h-4 text-[#FF7D00]" fill="#FF7D00" /> Bookmarked_Talents
-                        </h3>
-                        <BookmarkedFreelancers />
-                    </div>
-                    <div className="space-y-6">
-                        <h3 className="text-sm font-black uppercase font-mono tracking-[0.2em] text-zinc-400 flex items-center gap-2">
-                            <Send className="w-4 h-4 text-[#FF7D00]" /> Sent_Proposals_History
-                        </h3>
-                        <div className="bg-zinc-100/50 rounded-[2.5rem] border border-zinc-200 border-dashed p-10 flex flex-col items-center justify-center text-center">
-                            <Sparkles size={28} className="text-zinc-200 mb-4" />
-                            <p className="text-sm font-bold text-zinc-500 mb-1">준비 중인 프리미엄 기능</p>
-                            <p className="text-[11px] font-medium text-zinc-400 leading-relaxed">제안 내역과 피드백을 이곳에서 관리할 수 있습니다.</p>
-                        </div>
-                    </div>
-                </section>
-
+            <main className="max-w-6xl mx-auto px-10 py-16 relative z-10">
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-12 pt-8 border-t border-zinc-100">
                     {/* 설정 메뉴 */}
                     <div className="lg:col-span-1 space-y-6">
@@ -163,10 +142,10 @@ export default function ClientMyPage() {
                         </div>
                     </div>
 
-                    {/* 프로젝트 목록 */}
+                    {/* 프로젝트 목록 요약 */}
                     <div className="lg:col-span-2 space-y-6">
                         <div className="flex items-center justify-between">
-                            <h2 className="text-sm font-black uppercase font-mono tracking-[0.2em] text-zinc-400">My_Projects_List</h2>
+                            <h2 className="text-sm font-black uppercase font-mono tracking-[0.2em] text-zinc-400">Project_Snapshot</h2>
                             <span className="px-3 py-1 bg-zinc-950 text-white text-[10px] font-black rounded-lg font-mono">CNT_{projects.length}</span>
                         </div>
                         {loading ? (
@@ -196,8 +175,40 @@ export default function ClientMyPage() {
                 </div>
             </main>
 
-            {/* 프로젝트 상세 모달 (AnimatePresence 등 생략/유지) */}
-            {/* ... (이전 코드의 모달 부분 유지) */}
+            {/* 프로젝트 상세 모달 */}
+            <AnimatePresence>
+                {selectedProjectForView && (
+                    <div className="fixed inset-0 z-[100] flex items-center justify-center p-6">
+                        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} onClick={() => setSelectedProjectForView(null)} className="absolute inset-0 bg-zinc-950/70 backdrop-blur-md" />
+                        <motion.div initial={{ opacity: 0, scale: 0.9, y: 20 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.9, y: 20 }} className="relative bg-white rounded-[3.5rem] w-full max-w-xl p-12 shadow-2xl border border-orange-100 overflow-hidden">
+                            <div className="flex justify-between items-start mb-10 relative z-10">
+                                <div><span className="text-[10px] font-black text-[#FF7D00] uppercase tracking-[0.4em] font-mono block mb-2">Project_Briefing</span><h2 className="text-3xl font-black text-zinc-900 tracking-tighter leading-tight">{selectedProjectForView.projectName}</h2></div>
+                                <button onClick={() => setSelectedProjectForView(null)} className="text-zinc-300 hover:text-[#FF7D00] transition-colors p-2 bg-zinc-50 rounded-full"><XCircle size={28} /></button>
+                            </div>
+                            <div className="space-y-8 relative z-10">
+                                <div className="grid grid-cols-2 gap-5">
+                                    <div className="p-6 bg-zinc-50 rounded-[2rem] border border-zinc-100">
+                                        <p className="text-[10px] font-black text-zinc-400 uppercase mb-2 font-mono tracking-widest">Target_Budget</p>
+                                        <p className="text-xl font-black text-zinc-900">₩{selectedProjectForView.budget?.toLocaleString() || '0'}</p>
+                                    </div>
+                                    <div className="p-6 bg-zinc-50 rounded-[2rem] border border-zinc-100">
+                                        <p className="text-[10px] font-black text-zinc-400 uppercase mb-2 font-mono tracking-widest">Current_Status</p>
+                                        <p className="text-xl font-black text-[#FF7D00]">{selectedProjectForView.status}</p>
+                                    </div>
+                                </div>
+                                <div className="p-8 bg-zinc-50 rounded-[2.5rem] border border-zinc-100">
+                                    <p className="text-[10px] font-black text-zinc-400 uppercase mb-3 font-mono tracking-widest">Mission_Statement</p>
+                                    <p className="text-sm font-medium text-zinc-600 leading-relaxed italic">"{selectedProjectForView.detail || "제공된 상세 내용이 없습니다."}"</p>
+                                </div>
+                                <div className="flex gap-4 pt-4">
+                                    <button onClick={() => setSelectedProjectForView(null)} className="flex-1 py-5 bg-zinc-100 text-zinc-500 rounded-2xl font-black text-xs uppercase tracking-widest font-mono hover:bg-zinc-200 transition-all">Close</button>
+                                    <button onClick={() => router.push('/client/dashboard')} className="flex-1 py-5 bg-zinc-950 text-white rounded-2xl font-black text-xs uppercase tracking-widest font-mono hover:bg-[#FF7D00] shadow-xl flex items-center justify-center gap-3 transition-all">Manage_Now <ExternalLink size={16} /></button>
+                                </div>
+                            </div>
+                        </motion.div>
+                    </div>
+                )}
+            </AnimatePresence>
 
             <ProfileEditModal isOpen={isEditModalOpen} onClose={() => setIsEditModalOpen(false)} onSuccess={(newName) => setUser(prev => prev ? { ...prev, nickname: newName } : null)} />
             <CompanyEditModal isOpen={isCompanyModalOpen} onClose={() => setIsCompanyModalOpen(false)} onSuccess={() => {}} />


### PR DESCRIPTION
## 🔎 What

- 기존 마이페이지 에 존재했던 로직인 북마크와 제안내역을
대시보드로 이동하여 한꺼번에 관리하도록 루트 변경
-대시보드에서 북마크 및 제안내역 조회 api 연동
## 🔗 Issue

- Closes: #54 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-tab client dashboard with Projects, Bookmarks, and Proposals sections
  * Bookmark management with deletion
  * Sent proposals view with status, pricing, and date details
  * Project detail modal for quick viewing

* **UI/UX Improvements**
  * Inline expandable applicant panels per project
  * Streamlined mypage: updated project snapshot heading and removed bookmarked-freelancer section
  * Updated initial loading message text

* **Backend / Chores**
  * Backend adjustments related to project update handling and removed legacy search method
<!-- end of auto-generated comment: release notes by coderabbit.ai -->