### PR TITLE
feat]#90 integrate chat widget with chat room REST APIs

### DIFF
--- a/frontend/app/lib/chatApi.ts
+++ b/frontend/app/lib/chatApi.ts
@@ -1,4 +1,4 @@
-import { ChatMessageResponse, ChatRoomResponse } from "../types/chat";
+import { ChatMessageResponse, ChatRoomResponse } from "../../types/chat";
 
 const API_BASE_URL =
     process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080";

--- a/frontend/app/lib/chatApi.ts
+++ b/frontend/app/lib/chatApi.ts
@@ -1,0 +1,63 @@
+import { ChatMessageResponse, ChatRoomResponse } from "../types/chat";
+
+const API_BASE_URL =
+    process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080";
+
+function getAuthHeaders() {
+    if (typeof window === "undefined") {
+        return {
+            "Content-Type": "application/json",
+        };
+    }
+
+    const token = localStorage.getItem("accessToken");
+
+    return {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    };
+}
+
+export async function getChatRooms(): Promise<ChatRoomResponse[]> {
+    const response = await fetch(`${API_BASE_URL}/api/chat/rooms`, {
+        method: "GET",
+        headers: getAuthHeaders(),
+        cache: "no-store",
+    });
+
+    if (!response.ok) {
+        throw new Error("채팅방 목록 조회에 실패했습니다.");
+    }
+
+    return response.json();
+}
+
+export async function getChatMessages(
+    roomId: number
+): Promise<ChatMessageResponse[]> {
+    const response = await fetch(
+        `${API_BASE_URL}/api/chat/rooms/${roomId}/messages`,
+        {
+            method: "GET",
+            headers: getAuthHeaders(),
+            cache: "no-store",
+        }
+    );
+
+    if (!response.ok) {
+        throw new Error("채팅 메시지 조회에 실패했습니다.");
+    }
+
+    return response.json();
+}
+
+export async function markChatAsRead(roomId: number): Promise<void> {
+    const response = await fetch(`${API_BASE_URL}/api/chat/rooms/${roomId}/read`, {
+        method: "PATCH",
+        headers: getAuthHeaders(),
+    });
+
+    if (!response.ok) {
+        throw new Error("읽음 처리에 실패했습니다.");
+    }
+}

--- a/frontend/components/chat/ChatInput.tsx
+++ b/frontend/components/chat/ChatInput.tsx
@@ -30,7 +30,6 @@ export default function ChatInput({
                 <button
                     type="button"
                     onClick={onSend}
-                    aria-label="메시지 전송"
                     className="flex h-10 w-10 items-center justify-center rounded-full bg-violet-600 text-white hover:bg-violet-700"
                 >
                     ➤

--- a/frontend/components/chat/ChatMessageBubble.tsx
+++ b/frontend/components/chat/ChatMessageBubble.tsx
@@ -1,28 +1,32 @@
 interface ChatMessageBubbleProps {
-  message: string;
-  time: string;
-  isMine: boolean;
+    message: string;
+    time: string;
+    isMine: boolean;
 }
 
 export default function ChatMessageBubble({
-  message,
-  time,
-  isMine,
-}: ChatMessageBubbleProps) {
-  return (
-    <div className={`flex ${isMine ? "justify-end" : "justify-start"}`}>
-      <div className={`max-w-[75%] ${isMine ? "items-end" : "items-start"} flex flex-col`}>
-        <div
-          className={`px-4 py-3 rounded-2xl text-sm leading-relaxed break-words shadow-sm ${
-            isMine
-              ? "bg-violet-600 text-white rounded-br-md"
-              : "bg-white text-gray-900 border border-gray-200 rounded-bl-md"
-          }`}
-        >
-          {message}
+                                              message,
+                                              time,
+                                              isMine,
+                                          }: ChatMessageBubbleProps) {
+    return (
+        <div className={`flex ${isMine ? "justify-end" : "justify-start"}`}>
+            <div
+                className={`flex max-w-[75%] flex-col ${
+                    isMine ? "items-end" : "items-start"
+                }`}
+            >
+                <div
+                    className={`break-words rounded-2xl px-4 py-3 text-sm leading-relaxed shadow-sm ${
+                        isMine
+                            ? "rounded-br-md bg-violet-600 text-white"
+                            : "rounded-bl-md border border-gray-200 bg-white text-gray-900"
+                    }`}
+                >
+                    {message}
+                </div>
+                <span className="mt-1 px-1 text-[11px] text-gray-400">{time}</span>
+            </div>
         </div>
-        <span className="mt-1 px-1 text-[11px] text-gray-400">{time}</span>
-      </div>
-    </div>
-  );
+    );
 }

--- a/frontend/components/chat/ChatWidget.tsx
+++ b/frontend/components/chat/ChatWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import ChatWindow from "./ChatWindow";
 import {
     getChatMessages,
@@ -47,11 +47,18 @@ export default function ChatWidget() {
     };
 
     const fetchMessages = async (roomId: number) => {
+        const requestId = ++latestMessageReqId.current;
         try {
             setLoadingMessages(true);
             const messageData = await getChatMessages(roomId);
+            if (requestId !== latestMessageReqId.current) return;
             setMessages(messageData);
             await markChatAsRead(roomId);
+            setRooms((prev) =>
+                prev.map((room) =>
+                    room.roomId === roomId ? { ...room, unreadCount: 0 } : room
+                )
+            );
         } catch (error) {
             console.error("메시지 조회 실패", error);
         } finally {

--- a/frontend/components/chat/ChatWidget.tsx
+++ b/frontend/components/chat/ChatWidget.tsx
@@ -1,45 +1,74 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import ChatWindow from "./ChatWindow";
-
-const initialMessages = [
-    {
-        id: 1,
-        message: "안녕하세요! 문의 주신 내용 확인 도와드릴게요.",
-        time: "오후 2:10",
-        isMine: false,
-    },
-    {
-        id: 2,
-        message: "채팅 위젯 UI를 먼저 붙이고 있어요.",
-        time: "오후 2:11",
-        isMine: true,
-    },
-    {
-        id: 3,
-        message: "좋아요. 지금은 오른쪽 하단에 뜨는지만 확인하면 됩니다.",
-        time: "오후 2:12",
-        isMine: false,
-    },
-];
+import {
+    getChatMessages,
+    getChatRooms,
+    markChatAsRead,
+} from "../../app/lib/chatApi";
+import { ChatMessageResponse, ChatRoomResponse } from "../../types/chat";
 
 export default function ChatWidget() {
     const [isOpen, setIsOpen] = useState(false);
     const [input, setInput] = useState("");
-    const [messages, setMessages] = useState(initialMessages);
+
+    const [rooms, setRooms] = useState<ChatRoomResponse[]>([]);
+    const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
+    const [messages, setMessages] = useState<ChatMessageResponse[]>([]);
+
+    const [loadingRooms, setLoadingRooms] = useState(false);
+    const [loadingMessages, setLoadingMessages] = useState(false);
+
+    const fetchRooms = async () => {
+        try {
+            setLoadingRooms(true);
+            const roomData = await getChatRooms();
+            setRooms(roomData);
+
+            if (roomData.length > 0 && !selectedRoomId) {
+                setSelectedRoomId(roomData[0].roomId);
+            }
+        } catch (error) {
+            console.error("채팅방 조회 실패", error);
+        } finally {
+            setLoadingRooms(false);
+        }
+    };
+
+    const fetchMessages = async (roomId: number) => {
+        try {
+            setLoadingMessages(true);
+            const messageData = await getChatMessages(roomId);
+            setMessages(messageData);
+            await markChatAsRead(roomId);
+        } catch (error) {
+            console.error("메시지 조회 실패", error);
+        } finally {
+            setLoadingMessages(false);
+        }
+    };
+
+    useEffect(() => {
+        if (!isOpen) return;
+        fetchRooms();
+    }, [isOpen]);
+
+    useEffect(() => {
+        if (!isOpen || !selectedRoomId) return;
+        fetchMessages(selectedRoomId);
+    }, [isOpen, selectedRoomId]);
+
+    const handleOpenToggle = () => {
+        setIsOpen((prev) => !prev);
+    };
+
+    const handleSelectRoom = (roomId: number) => {
+        setSelectedRoomId(roomId);
+    };
 
     const handleSend = () => {
         if (!input.trim()) return;
-
-        const newMessage = {
-            id: Date.now(),
-            message: input,
-            time: "방금",
-            isMine: true,
-        };
-
-        setMessages((prev) => [...prev, newMessage]);
         setInput("");
     };
 
@@ -48,15 +77,20 @@ export default function ChatWidget() {
             <ChatWindow
                 isOpen={isOpen}
                 onClose={() => setIsOpen(false)}
+                rooms={rooms}
+                selectedRoomId={selectedRoomId}
+                onSelectRoom={handleSelectRoom}
                 messages={messages}
                 input={input}
                 onChangeInput={setInput}
                 onSend={handleSend}
+                loadingRooms={loadingRooms}
+                loadingMessages={loadingMessages}
             />
 
             <button
                 type="button"
-                onClick={() => setIsOpen((prev) => !prev)}
+                onClick={handleOpenToggle}
                 className="fixed bottom-6 right-6 z-[9999] flex h-16 w-16 items-center justify-center rounded-full bg-violet-600 text-2xl text-white shadow-xl transition hover:scale-105 hover:bg-violet-700"
                 aria-label="채팅 열기"
             >

--- a/frontend/components/chat/ChatWidget.tsx
+++ b/frontend/components/chat/ChatWidget.tsx
@@ -8,11 +8,12 @@ import {
     markChatAsRead,
 } from "../../app/lib/chatApi";
 import { ChatMessageResponse, ChatRoomResponse } from "../../types/chat";
+import { getCurrentUserId } from "../../app/lib/auth";
 
 export default function ChatWidget() {
     const [isOpen, setIsOpen] = useState(false);
     const [input, setInput] = useState("");
-
+    const currentUserId = getCurrentUserId();
     const [rooms, setRooms] = useState<ChatRoomResponse[]>([]);
     const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
     const [messages, setMessages] = useState<ChatMessageResponse[]>([]);
@@ -103,6 +104,7 @@ export default function ChatWidget() {
                 onSend={handleSend}
                 loadingRooms={loadingRooms}
                 loadingMessages={loadingMessages}
+                currentUserId={currentUserId}
             />
 
             <button

--- a/frontend/components/chat/ChatWidget.tsx
+++ b/frontend/components/chat/ChatWidget.tsx
@@ -26,7 +26,17 @@ export default function ChatWidget() {
             const roomData = await getChatRooms();
             setRooms(roomData);
 
-            if (roomData.length > 0 && !selectedRoomId) {
+            if (roomData.length === 0) {
+                setSelectedRoomId(null);
+                setMessages([]);
+                return;
+            }
+
+            const selectedStillExists =
+                selectedRoomId !== null &&
+                roomData.some((room) => room.roomId === selectedRoomId);
+
+            if (!selectedStillExists) {
                 setSelectedRoomId(roomData[0].roomId);
             }
         } catch (error) {

--- a/frontend/components/chat/ChatWindow.tsx
+++ b/frontend/components/chat/ChatWindow.tsx
@@ -4,30 +4,34 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import ChatInput from "./ChatInput";
 import ChatMessageBubble from "./ChatMessageBubble";
-
-interface DummyMessage {
-    id: number;
-    message: string;
-    time: string;
-    isMine: boolean;
-}
+import { ChatMessageResponse, ChatRoomResponse } from "../../types/chat";
 
 interface ChatWindowProps {
     isOpen: boolean;
     onClose: () => void;
-    messages: DummyMessage[];
+    rooms: ChatRoomResponse[];
+    selectedRoomId: number | null;
+    onSelectRoom: (roomId: number) => void;
+    messages: ChatMessageResponse[];
     input: string;
     onChangeInput: (value: string) => void;
     onSend: () => void;
+    loadingRooms: boolean;
+    loadingMessages: boolean;
 }
 
 export default function ChatWindow({
                                        isOpen,
                                        onClose,
+                                       rooms,
+                                       selectedRoomId,
+                                       onSelectRoom,
                                        messages,
                                        input,
                                        onChangeInput,
                                        onSend,
+                                       loadingRooms,
+                                       loadingMessages,
                                    }: ChatWindowProps) {
     const [mounted, setMounted] = useState(false);
 
@@ -50,35 +54,72 @@ export default function ChatWindow({
             className="flex flex-col overflow-hidden rounded-3xl border border-gray-200 bg-white shadow-2xl"
         >
             <div className="flex items-center justify-between border-b border-gray-100 bg-white px-5 py-4">
-                <div className="flex items-center gap-3">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-violet-100 text-lg">
-                        👤
-                    </div>
-                    <div>
-                        <p className="text-sm font-semibold text-gray-900">1:1 채팅</p>
-                        <p className="text-xs text-gray-400">현재는 UI 미리보기 단계입니다</p>
-                    </div>
+                <div>
+                    <p className="text-sm font-semibold text-gray-900">1:1 채팅</p>
+                    <p className="text-xs text-gray-400">채팅방과 메시지를 불러옵니다</p>
                 </div>
 
                 <button
                     type="button"
                     onClick={onClose}
-                    aria-label="채팅 닫기"
                     className="text-xl text-gray-400 hover:text-gray-600"
                 >
                     ×
                 </button>
             </div>
 
+            <div className="border-b border-gray-100 bg-white px-3 py-2">
+                <div className="flex gap-2 overflow-x-auto">
+                    {loadingRooms ? (
+                        <div className="px-2 py-1 text-xs text-gray-400">
+                            채팅방 불러오는 중...
+                        </div>
+                    ) : rooms.length === 0 ? (
+                        <div className="px-2 py-1 text-xs text-gray-400">
+                            채팅방이 없습니다.
+                        </div>
+                    ) : (
+                        rooms.map((room) => (
+                            <button
+                                key={room.roomId}
+                                type="button"
+                                onClick={() => onSelectRoom(room.roomId)}
+                                className={`shrink-0 rounded-full border px-3 py-1 text-xs ${
+                                    selectedRoomId === room.roomId
+                                        ? "border-violet-600 bg-violet-600 text-white"
+                                        : "border-gray-200 bg-white text-gray-700"
+                                }`}
+                            >
+                                {room.otherNickname}
+                                {room.unreadCount > 0 ? ` (${room.unreadCount})` : ""}
+                            </button>
+                        ))
+                    )}
+                </div>
+            </div>
+
             <div className="flex-1 space-y-3 overflow-y-auto bg-gray-50 px-4 py-4">
-                {messages.map((msg) => (
-                    <ChatMessageBubble
-                        key={msg.id}
-                        message={msg.message}
-                        time={msg.time}
-                        isMine={msg.isMine}
-                    />
-                ))}
+                {loadingMessages ? (
+                    <div className="flex h-full items-center justify-center text-sm text-gray-400">
+                        메시지를 불러오는 중...
+                    </div>
+                ) : messages.length === 0 ? (
+                    <div className="flex h-full items-center justify-center text-sm text-gray-400">
+                        아직 메시지가 없습니다.
+                    </div>
+                ) : (
+                    messages.map((msg) => (
+                        <ChatMessageBubble
+                            key={msg.id}
+                            message={msg.message}
+                            time={new Date(msg.createdAt).toLocaleTimeString([], {
+                                hour: "2-digit",
+                                minute: "2-digit",
+                            })}
+                            isMine={false}
+                        />
+                    ))
+                )}
             </div>
 
             <ChatInput value={input} onChange={onChangeInput} onSend={onSend} />

--- a/frontend/components/chat/ChatWindow.tsx
+++ b/frontend/components/chat/ChatWindow.tsx
@@ -116,7 +116,7 @@ export default function ChatWindow({
                                 hour: "2-digit",
                                 minute: "2-digit",
                             })}
-                            isMine={false}
+                            isMine={msg.senderId === currentUserId}
                         />
                     ))
                 )}

--- a/frontend/components/chat/ChatWindow.tsx
+++ b/frontend/components/chat/ChatWindow.tsx
@@ -18,6 +18,7 @@ interface ChatWindowProps {
     onSend: () => void;
     loadingRooms: boolean;
     loadingMessages: boolean;
+    currentUserId: number | null;
 }
 
 export default function ChatWindow({
@@ -32,6 +33,7 @@ export default function ChatWindow({
                                        onSend,
                                        loadingRooms,
                                        loadingMessages,
+                                       currentUserId,
                                    }: ChatWindowProps) {
     const [mounted, setMounted] = useState(false);
 

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -1,0 +1,27 @@
+export interface ChatRoomResponse {
+    roomId: number;
+    otherUserId: number;
+    otherNickname: string;
+    lastMessage: string | null;
+    lastMessageTime: string | null;
+    unreadCount: number;
+}
+
+export interface ChatMessageResponse {
+    id: number;
+    roomId: number;
+    senderId: number;
+    senderNickname: string;
+    message: string;
+    createdAt: string;
+    read: boolean;
+}
+
+export interface ChatRoomCreateRequest {
+    targetUserId: number;
+}
+
+export interface ChatMessageSendRequest {
+    roomId: number;
+    message: string;
+}


### PR DESCRIPTION
## 🔎 What

- 채팅 위젯 UI를 실제 채팅 REST API와 연결
- 채팅방 목록 조회 기능 추가
- 선택한 채팅방의 메시지 조회 흐름 추가
- 채팅창 오픈 시 채팅방 목록을 불러오도록 구현
- 채팅방이 없는 경우 empty state UI가 표시되도록 처리

## 주요 구현 사항
- ChatWidget에서 채팅방/메시지 상태 관리
- ChatWindow에서 채팅방 목록 및 메시지 영역 렌더링
- chatApi helper를 통해 채팅방 조회, 메시지 조회, 읽음 처리 API 연결
- 채팅창 위치 문제를 portal 기반으로 유지

## 현재 확인된 상태
- 프론트 UI 및 REST API 연결은 정상 동작
- 현재 테스트 계정 기준 채팅방 데이터가 없어 "채팅방이 없습니다." empty state로 확인함
- 실제 채팅방 데이터가 존재하면 이후 메시지 조회 흐름으로 이어질 예정

## 비고
- 이번 PR에는 실시간 WebSocket 연결은 포함하지 않음
- 메시지 실제 전송 기능은 다음 PR에서 연결 예정
- 추후 채팅방 생성/실데이터 기반 테스트 필요

## 🔗 Issue

- Closes: #90

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select and switch between chat rooms with unread counts and horizontal scrolling
  * Messages and room lists load from server; loading/empty states shown; times localized
  * Messages marked as read when viewed; send clears input (no optimistic local append)
  * Added chat API integration and standardized chat data types

* **Style**
  * Chat layout and message bubble markup reorganized for clearer structure and readability

* **Other**
  * Minor accessibility attribute removals from chat controls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->