### PR TITLE
[feat] #108 벌크 데이터 변경 및 ai 태그 검색

### DIFF
--- a/backend/src/main/java/com/devnear/global/seed/DemoBulkSeedService.java
+++ b/backend/src/main/java/com/devnear/global/seed/DemoBulkSeedService.java
@@ -56,10 +56,34 @@ public class DemoBulkSeedService {
     private static final String MARKER_EMAIL = "bulk-demo-freelancer-01@local.test";
     private static final String DEMO_PASSWORD = "BulkDemo1!";
 
-    private static final int FREELANCERS = 10;
-    private static final int CLIENTS = 10;
-    private static final int PORTFOLIOS = 50;
-    private static final int PROJECTS = 50;
+    private static final int FREELANCERS = 20;
+    private static final int CLIENTS = 20;
+    /** 프리랜서 1인당 포트폴리오 개수 */
+    private static final int PORTFOLIOS_PER_FREELANCER = 3;
+    /** 클라이언트 1인당 모집 공고 개수 */
+    private static final int PROJECTS_PER_CLIENT = 3;
+    private static final int PORTFOLIOS = FREELANCERS * PORTFOLIOS_PER_FREELANCER;
+    private static final int PROJECTS = CLIENTS * PROJECTS_PER_CLIENT;
+
+    /** 시드 공고·거주지 분산용 한국 주요 도시(대략 중심 좌표) */
+    private record KoreanCitySpot(String label, double latitude, double longitude) {
+    }
+
+    private static final KoreanCitySpot[] KOREAN_MAJOR_CITIES = {
+            new KoreanCitySpot("서울 강남", 37.4980, 127.0286),
+            new KoreanCitySpot("부산 해운대", 35.1631, 129.1636),
+            new KoreanCitySpot("대구 중구", 35.8714, 128.6014),
+            new KoreanCitySpot("인천 연수", 37.4100, 126.6788),
+            new KoreanCitySpot("광주 서구", 35.1520, 126.8903),
+            new KoreanCitySpot("대전 유성", 36.3623, 127.3845),
+            new KoreanCitySpot("울산 남구", 35.5384, 129.3114),
+            new KoreanCitySpot("세종 종촌", 36.4800, 127.2890),
+            new KoreanCitySpot("수원 영통", 37.2636, 127.0286),
+            new KoreanCitySpot("창원 성산", 35.2279, 128.6817),
+            new KoreanCitySpot("고양 일산", 37.6584, 126.8320),
+            new KoreanCitySpot("용인 기흥", 37.2752, 127.1156),
+            new KoreanCitySpot("제주 시내", 33.4996, 126.5312),
+    };
 
     /** {@link com.devnear.global.config.DefaultSkillCatalog}와 동일한 이름이어야 조회됨 */
     private static final String[] DEFAULT_SKILL_NAMES_FOR_SEED = DefaultSkillCatalog.NAMES;
@@ -163,8 +187,8 @@ public class DemoBulkSeedService {
         }
         log.info("[DemoBulkSeed] 임베딩 시도 {}/{}건 완료", embedded, projectIds.size());
 
-        log.info("[DemoBulkSeed] 완료 — 클라이언트 {}, 프리랜서 {}(등급·리뷰·이미지·완료건수 랜덤), 포트폴리오 {}(썸네일·갤러리), 공고 {}. 비밀번호: {}",
-                CLIENTS, FREELANCERS, PORTFOLIOS, PROJECTS, DEMO_PASSWORD);
+        log.info("[DemoBulkSeed] 완료 — 클라이언트 {}(공고 {}건/인), 프리랜서 {}(포트폴리오 {}건/인·등급·리뷰·이미지·완료건수 랜덤), 합계 공고 {}·포트폴리오 {}. 비밀번호: {}",
+                CLIENTS, PROJECTS_PER_CLIENT, FREELANCERS, PORTFOLIOS_PER_FREELANCER, PROJECTS, PORTFOLIOS, DEMO_PASSWORD);
     }
 
     /** 단일 트랜잭션: 사용자·프로필·포트폴리오·공고 행 삽입만 수행하고 생성된 공고 ID 목록을 반환합니다. */
@@ -227,13 +251,16 @@ public class DemoBulkSeedService {
                     .build());
 
             FreelancerGrade grade = gradePool[rnd.nextInt(gradePool.length)];
+            KoreanCitySpot home = KOREAN_MAJOR_CITIES[(i - 1) % KOREAN_MAJOR_CITIES.length];
+            double jitterLat = (rnd.nextDouble() - 0.5) * 0.06;
+            double jitterLon = (rnd.nextDouble() - 0.5) * 0.06;
             FreelancerProfile fp = FreelancerProfile.builder()
                     .user(user)
                     .profileImageUrl(avatarUrl)
                     .introduction("풀스택·" + TOPICS[i % TOPICS.length] + " 경험. 원격/대면 모두 가능합니다.")
-                    .location("서울")
-                    .latitude(37.5 + i * 0.01)
-                    .longitude(127.0 + i * 0.01)
+                    .location(home.label())
+                    .latitude(home.latitude() + jitterLat)
+                    .longitude(home.longitude() + jitterLon)
                     .hourlyRate(50000 + i * 5000)
                     .workStyle(WorkStyle.HYBRID)
                     .isActive(true)
@@ -245,52 +272,64 @@ public class DemoBulkSeedService {
             freelancerProfiles.add(fp);
         }
 
-        for (int p = 0; p < PORTFOLIOS; p++) {
-            User owner = freelancerUsers.get(p % freelancerUsers.size());
-            String topic = TOPICS[p % TOPICS.length];
-            String thumb = picsumUrl("bulk-pf-thumb-" + p, 800, 450);
-            Portfolio portfolio = Portfolio.builder()
-                    .user(owner)
-                    .title(topic + " 포트폴리오 #" + (p + 1))
-                    .desc("역할: 리드 개발. 스택: Java, Spring, React. " + topic
-                            + " 도메인에서 API 설계, DB 모델링, 배포 자동화까지 수행했습니다. (시드 데이터)")
-                    .thumbnailUrl(thumb)
-                    .build();
-            attachSeedPortfolioSkills(portfolio, topic, p);
-            portfolio.addPortfolioImage(PortfolioImage.builder()
-                    .portfolio(portfolio)
-                    .imageUrl(picsumUrl("bulk-pf-img-" + p + "-a", 1200, 800))
-                    .sortOrder(0)
-                    .build());
-            portfolio.addPortfolioImage(PortfolioImage.builder()
-                    .portfolio(portfolio)
-                    .imageUrl(picsumUrl("bulk-pf-img-" + p + "-b", 1200, 800))
-                    .sortOrder(1)
-                    .build());
-            portfolioRepository.save(portfolio);
+        int portfolioSeq = 0;
+        for (int fi = 0; fi < freelancerUsers.size(); fi++) {
+            User owner = freelancerUsers.get(fi);
+            for (int k = 0; k < PORTFOLIOS_PER_FREELANCER; k++) {
+                String topic = TOPICS[portfolioSeq % TOPICS.length];
+                String thumb = picsumUrl("bulk-pf-thumb-" + portfolioSeq, 800, 450);
+                Portfolio portfolio = Portfolio.builder()
+                        .user(owner)
+                        .title(topic + " 포트폴리오 #" + (portfolioSeq + 1))
+                        .desc("역할: 리드 개발. 스택: Java, Spring, React. " + topic
+                                + " 도메인에서 API 설계, DB 모델링, 배포 자동화까지 수행했습니다. (시드 데이터)")
+                        .thumbnailUrl(thumb)
+                        .build();
+                attachSeedPortfolioSkills(portfolio, topic, portfolioSeq);
+                portfolio.addPortfolioImage(PortfolioImage.builder()
+                        .portfolio(portfolio)
+                        .imageUrl(picsumUrl("bulk-pf-img-" + portfolioSeq + "-a", 1200, 800))
+                        .sortOrder(0)
+                        .build());
+                portfolio.addPortfolioImage(PortfolioImage.builder()
+                        .portfolio(portfolio)
+                        .imageUrl(picsumUrl("bulk-pf-img-" + portfolioSeq + "-b", 1200, 800))
+                        .sortOrder(1)
+                        .build());
+                portfolioRepository.save(portfolio);
+                portfolioSeq++;
+            }
         }
 
         List<Long> projectIds = new ArrayList<>(PROJECTS);
         LocalDate baseDeadline = LocalDate.now().plusMonths(2);
-        for (int j = 0; j < PROJECTS; j++) {
-            ClientProfile client = clientProfiles.get(j % clientProfiles.size());
-            String topic = TOPICS[j % TOPICS.length];
-            Project project = Project.builder()
-                    .clientProfile(client)
-                    .projectName(topic + " 모집 #" + (j + 1))
-                    .budget(3_000_000 + j * 100_000)
-                    .deadline(baseDeadline.plusDays(j % 60))
-                    .detail("모집 개요(시드): " + topic + " 관련 기능 개발. REST API, 단위 테스트, 코드 리뷰, 문서화 포함."
-                            + " 우대: TypeScript, 클라우드 경험. 일정 협의 가능.")
-                    .online(true)
-                    .offline(j % 3 == 0)
-                    .location(j % 3 == 0 ? "서울 강남" : null)
-                    .latitude(j % 3 == 0 ? 37.498 : null)
-                    .longitude(j % 3 == 0 ? 127.028 : null)
-                    .build();
-            attachSeedProjectSkills(project, topic, j);
-            Project saved = projectRepository.save(project);
-            projectIds.add(saved.getId());
+        int projectSeq = 0;
+        for (int ci = 0; ci < clientProfiles.size(); ci++) {
+            ClientProfile client = clientProfiles.get(ci);
+            for (int k = 0; k < PROJECTS_PER_CLIENT; k++) {
+                KoreanCitySpot spot = KOREAN_MAJOR_CITIES[(ci * PROJECTS_PER_CLIENT + k) % KOREAN_MAJOR_CITIES.length];
+                double pJitterLat = (rnd.nextDouble() - 0.5) * 0.04;
+                double pJitterLon = (rnd.nextDouble() - 0.5) * 0.04;
+                String topic = TOPICS[projectSeq % TOPICS.length];
+                boolean offline = (projectSeq % 2 == 0);
+                Project project = Project.builder()
+                        .clientProfile(client)
+                        .projectName(topic + " 모집 #" + (projectSeq + 1))
+                        .budget(3_000_000 + projectSeq * 100_000)
+                        .deadline(baseDeadline.plusDays(projectSeq % 60))
+                        .detail("모집 개요(시드): " + topic + " 관련 기능 개발. REST API, 단위 테스트, 코드 리뷰, 문서화 포함."
+                                + " 우대: TypeScript, 클라우드 경험. 일정 협의 가능. 근무·미팅 지역: " + spot.label() + ".")
+                        .online(true)
+                        .offline(offline)
+                        .location(spot.label())
+                        .latitude(spot.latitude() + pJitterLat)
+                        .longitude(spot.longitude() + pJitterLon)
+                        .build();
+                attachSeedProjectSkills(project, topic, projectSeq);
+                Project saved = projectRepository.save(project);
+                projectIds.add(saved.getId());
+                projectSeq++;
+            }
         }
 
         seedFreelancerReviews(freelancerProfiles, clientProfiles, projectIds, rnd);

--- a/backend/src/main/java/com/devnear/web/service/skill/SkillService.java
+++ b/backend/src/main/java/com/devnear/web/service/skill/SkillService.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -111,6 +112,8 @@ public class SkillService {
         if (text.isBlank()) {
             return List.of();
         }
+        /** 휴리스틱·NLP 후보 축소: 한글 표기를 카탈로그 영문명과 동일한 정규화 토큰으로 덧붙입니다. */
+        String textForMatch = augmentDocumentWithKoreanSkillAliases(text);
         int topN = limit == null ? 8 : Math.min(Math.max(1, limit), 20);
         List<Skill> allSkills = skillRepository.findAll();
         if (allSkills.isEmpty()) {
@@ -118,7 +121,7 @@ public class SkillService {
         }
         if (geminiSkillTagSuggestionClient.isConfigured()) {
             try {
-                List<Skill> catalog = catalogForNlp(text, allSkills);
+                List<Skill> catalog = catalogForNlp(textForMatch, allSkills);
                 List<GeminiSkillPick> picks = geminiSkillTagSuggestionClient.suggestFromDocument(
                         rawText, context, catalog, topN);
                 if (!picks.isEmpty()) {
@@ -144,7 +147,7 @@ public class SkillService {
                 log.warn("NLP 스킬 추출 실패, 규칙 기반으로 대체: {}", e.getMessage());
             }
         }
-        return heuristicSuggestTagsFromText(text, allSkills, topN);
+        return heuristicSuggestTagsFromText(textForMatch, allSkills, topN);
     }
 
     /**
@@ -208,6 +211,140 @@ public class SkillService {
 
     /** 짧은 스킬 토큰(1~2글자)은 문서 토큰과 완전 일치할 때만 매칭합니다. */
     private static final int SHORT_TOKEN_MAX_LEN = 2;
+
+    /**
+     * 기본 스킬 카탈로그가 영문명 위주일 때, 본문의 한글 표기와 매칭되도록 동의어를 뒤에 붙입니다.
+     * (Gemini는 원문 rawText를 그대로 읽고, 이 보강은 휴리스틱·catalogForNlp 전용입니다.)
+     */
+    private static String augmentDocumentWithKoreanSkillAliases(String normalizedDoc) {
+        if (normalizedDoc.isBlank()) {
+            return normalizedDoc;
+        }
+        String compactDoc = compact(normalizedDoc);
+        LinkedHashSet<String> extras = new LinkedHashSet<>();
+        for (KrSkillAlias rule : KR_SKILL_ALIASES_SORTED) {
+            if (!rule.docGuard().test(normalizedDoc)) {
+                continue;
+            }
+            String kr = rule.koreanPhrase();
+            if (kr.isBlank()) {
+                continue;
+            }
+            if (normalizedDoc.contains(kr) || compactDoc.contains(compact(kr))) {
+                String en = rule.englishSkillNormalized();
+                if (!en.isBlank()) {
+                    extras.add(en);
+                }
+            }
+        }
+        if (extras.isEmpty()) {
+            return normalizedDoc;
+        }
+        return normalizedDoc + " " + String.join(" ", extras);
+    }
+
+    private record KrSkillAlias(
+            String koreanPhrase,
+            String englishSkillNormalized,
+            Predicate<String> docGuard
+    ) {
+        static KrSkillAlias of(String koreanRaw, String englishSkillName) {
+            return new KrSkillAlias(
+                    normalize(koreanRaw),
+                    normalize(englishSkillName),
+                    doc -> true
+            );
+        }
+
+        static KrSkillAlias ofUnlessDocContains(String koreanRaw, String englishSkillName, String unlessDocSubstring) {
+            String unless = normalize(unlessDocSubstring);
+            return new KrSkillAlias(
+                    normalize(koreanRaw),
+                    normalize(englishSkillName),
+                    doc -> unless.isEmpty() || !doc.contains(unless)
+            );
+        }
+    }
+
+    /**
+     * 긴 한글 구절을 먼저 두면, 짧은 구절이 부분 문자열로 오탐하는 경우를 줄입니다.
+     */
+    private static final KrSkillAlias[] KR_SKILL_ALIASES_SORTED = buildKrSkillAliasesSorted();
+
+    private static KrSkillAlias[] buildKrSkillAliasesSorted() {
+        List<KrSkillAlias> rules = new ArrayList<>(List.of(
+                KrSkillAlias.of("스프링 부트", "Spring Boot"),
+                KrSkillAlias.of("스프링부트", "Spring Boot"),
+                KrSkillAlias.ofUnlessDocContains("리액트", "React", "리액트 네이티브"),
+                KrSkillAlias.of("리액트 네이티브", "React Native"),
+                KrSkillAlias.of("리액트네이티브", "React Native"),
+                KrSkillAlias.of("타입스크립트", "TypeScript"),
+                KrSkillAlias.of("넥스트js", "Next.js"),
+                KrSkillAlias.of("넥스트.js", "Next.js"),
+                KrSkillAlias.of("노드js", "Node.js"),
+                KrSkillAlias.of("노드.js", "Node.js"),
+                KrSkillAlias.of("파이썬", "Python"),
+                KrSkillAlias.of("쿠버네티스", "Kubernetes"),
+                KrSkillAlias.of("깃허브 액션", "GitHub Actions"),
+                KrSkillAlias.of("깃허브액션", "GitHub Actions"),
+                KrSkillAlias.of("스프링 시큐리티", "Spring Security"),
+                KrSkillAlias.of("그래큐엘", "GraphQL"),
+                KrSkillAlias.of("포스트그레스큐엘", "PostgreSQL"),
+                KrSkillAlias.of("포스트그레스", "PostgreSQL"),
+                KrSkillAlias.of("마이에스큐엘", "MySQL"),
+                KrSkillAlias.of("마이에스큐", "MySQL"),
+                KrSkillAlias.of("몽고디비", "MongoDB"),
+                KrSkillAlias.of("엘라스틱서치", "Elasticsearch"),
+                KrSkillAlias.of("아파치 카프카", "Apache Kafka"),
+                KrSkillAlias.of("카프카", "Apache Kafka"),
+                KrSkillAlias.of("래빗엠큐", "RabbitMQ"),
+                KrSkillAlias.of("아파치 스파크", "Apache Spark"),
+                KrSkillAlias.of("익스프레스", "Express.js"),
+                KrSkillAlias.of("네스트js", "NestJS"),
+                KrSkillAlias.of("네스트.js", "NestJS"),
+                KrSkillAlias.of("뷰js", "Vue.js"),
+                KrSkillAlias.of("뷰.js", "Vue.js"),
+                KrSkillAlias.of("앵귤러", "Angular"),
+                KrSkillAlias.of("스위프트", "Swift"),
+                KrSkillAlias.of("플러터", "Flutter"),
+                KrSkillAlias.of("장고", "Django"),
+                KrSkillAlias.of("패스트api", "FastAPI"),
+                KrSkillAlias.of("코틀린", "Kotlin"),
+                KrSkillAlias.of("고랭", "Go"),
+                KrSkillAlias.of("테라폼", "Terraform"),
+                KrSkillAlias.of("젠킨스", "Jenkins"),
+                KrSkillAlias.of("리눅스", "Linux"),
+                KrSkillAlias.of("엔진엑스", "Nginx"),
+                KrSkillAlias.of("웹소켓", "WebSocket"),
+                KrSkillAlias.of("제이피에이", "JPA"),
+                KrSkillAlias.of("쿼리dsl", "Querydsl"),
+                KrSkillAlias.of("쿼리 디에스엘", "Querydsl"),
+                KrSkillAlias.of("마이크로서비스", "MSA"),
+                KrSkillAlias.of("마이크로 서비스", "MSA"),
+                KrSkillAlias.of("솔리드", "SOLID"),
+                KrSkillAlias.of("캐싱", "Caching"),
+                KrSkillAlias.of("샤딩", "Database Sharding"),
+                KrSkillAlias.of("데이터베이스 샤딩", "Database Sharding"),
+                KrSkillAlias.of("매칭 알고리즘", "Matching Algorithm"),
+                KrSkillAlias.of("솔리디티", "Solidity"),
+                KrSkillAlias.of("자바", "Java"),
+                KrSkillAlias.of("도커", "Docker"),
+                KrSkillAlias.of("레디스", "Redis"),
+                KrSkillAlias.of("에이더블유에스", "AWS"),
+                KrSkillAlias.of("지피알씨", "gRPC"),
+                KrSkillAlias.of("파이어베이스", "Firebase"),
+                KrSkillAlias.of("오쓰", "OAuth2"),
+                KrSkillAlias.of("오쓰2", "OAuth2"),
+                KrSkillAlias.of("제스트", "Jest"),
+                KrSkillAlias.of("사이프레스", "Cypress"),
+                KrSkillAlias.of("스토리북", "Storybook"),
+                KrSkillAlias.of("사스", "Sass"),
+                KrSkillAlias.of("테일윈드", "Tailwind CSS"),
+                KrSkillAlias.of("웹팩", "Webpack")
+        ));
+        rules.sort(Comparator.comparingInt((KrSkillAlias r) -> r.koreanPhrase().length()).reversed());
+        return rules.toArray(KrSkillAlias[]::new);
+    }
 
     private static double scoreSkill(String text, String skillName) {
         if (text.isBlank() || skillName.isBlank()) {

--- a/backend/src/main/java/com/devnear/web/service/skill/SkillService.java
+++ b/backend/src/main/java/com/devnear/web/service/skill/SkillService.java
@@ -258,10 +258,11 @@ public class SkillService {
 
         static KrSkillAlias ofUnlessDocContains(String koreanRaw, String englishSkillName, String unlessDocSubstring) {
             String unless = normalize(unlessDocSubstring);
+            String unlessCompact = compact(unless);
             return new KrSkillAlias(
                     normalize(koreanRaw),
                     normalize(englishSkillName),
-                    doc -> unless.isEmpty() || !doc.contains(unless)
+                    doc -> unless.isEmpty() || (!doc.contains(unless) && !compact(doc).contains(unlessCompact))
             );
         }
     }

--- a/backend/src/main/java/com/devnear/web/service/skill/SkillService.java
+++ b/backend/src/main/java/com/devnear/web/service/skill/SkillService.java
@@ -217,13 +217,18 @@ public class SkillService {
     /**
      * 본문(정규화)에 등장한 한글 별칭에 대응하는 카탈로그 영문 스킬명(정규화) 집합.
      * 문서 문자열을 바꾸지 않으며, {@link #scoreSkillForSuggest}에서 해당 스킬과 정확히 일치할 때만 가산합니다.
+     * <p>
+     * {@link #KR_SKILL_ALIASES_SORTED}는 한글 구절 길이 내림차순입니다. 매칭은 {@link #compact} 문자열에서 수행하고,
+     * 이미 수락한 구간과 겹치는 짧은 별칭(예: "자바" ⊂ "자바스크립트")은 무시합니다.
      */
-    private static LinkedHashSet<String> collectKoreanAliasEnglishHits(String normalizedDoc) {
+    static LinkedHashSet<String> collectKoreanAliasEnglishHits(String normalizedDoc) {
         LinkedHashSet<String> extras = new LinkedHashSet<>();
         if (normalizedDoc == null || normalizedDoc.isBlank()) {
             return extras;
         }
         String compactDoc = compact(normalizedDoc);
+        List<int[]> compactConsumed = new ArrayList<>();
+
         for (KrSkillAlias rule : KR_SKILL_ALIASES_SORTED) {
             if (!rule.docGuard().test(normalizedDoc)) {
                 continue;
@@ -232,14 +237,41 @@ public class SkillService {
             if (kr.isBlank()) {
                 continue;
             }
-            if (normalizedDoc.contains(kr) || compactDoc.contains(compact(kr))) {
-                String en = rule.englishSkillNormalized();
-                if (!en.isBlank()) {
+            String krCompact = compact(kr);
+            if (krCompact.isBlank()) {
+                continue;
+            }
+            String en = rule.englishSkillNormalized();
+            if (en.isBlank()) {
+                continue;
+            }
+            int from = 0;
+            while (from <= compactDoc.length() - krCompact.length()) {
+                int j = compactDoc.indexOf(krCompact, from);
+                if (j < 0) {
+                    break;
+                }
+                int end = j + krCompact.length();
+                if (!overlapsAnySpan(compactConsumed, j, end)) {
+                    compactConsumed.add(new int[]{j, end});
                     extras.add(en);
+                    from = j + 1;
+                } else {
+                    from = j + 1;
                 }
             }
         }
         return extras;
+    }
+
+    /** half-open {@code [start, end)} 구간이 기록된 구간들 중 하나와 겹치면 true */
+    private static boolean overlapsAnySpan(List<int[]> intervals, int start, int endExclusive) {
+        for (int[] iv : intervals) {
+            if (endExclusive > iv[0] && start < iv[1]) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -342,6 +374,8 @@ public class SkillService {
                 KrSkillAlias.of("데이터베이스 샤딩", "Database Sharding"),
                 KrSkillAlias.of("매칭 알고리즘", "Matching Algorithm"),
                 KrSkillAlias.of("솔리디티", "Solidity"),
+                /** "자바" 단독은 허용하되 "자바스크립트" 내부 부분 문자열로 Java 오인 방지(긴 구절이 먼저 소비) */
+                KrSkillAlias.of("자바스크립트", "JavaScript"),
                 KrSkillAlias.of("자바", "Java"),
                 KrSkillAlias.of("도커", "Docker"),
                 KrSkillAlias.of("레디스", "Redis"),

--- a/backend/src/main/java/com/devnear/web/service/skill/SkillService.java
+++ b/backend/src/main/java/com/devnear/web/service/skill/SkillService.java
@@ -112,8 +112,8 @@ public class SkillService {
         if (text.isBlank()) {
             return List.of();
         }
-        /** 휴리스틱·NLP 후보 축소: 한글 표기를 카탈로그 영문명과 동일한 정규화 토큰으로 덧붙입니다. */
-        String textForMatch = augmentDocumentWithKoreanSkillAliases(text);
+        /** 한글 별칭 → 카탈로그 영문명 정규화 문자열. 문서는 수정하지 않고 점수에만 반영합니다. */
+        LinkedHashSet<String> koreanAliasEnglishHits = collectKoreanAliasEnglishHits(text);
         int topN = limit == null ? 8 : Math.min(Math.max(1, limit), 20);
         List<Skill> allSkills = skillRepository.findAll();
         if (allSkills.isEmpty()) {
@@ -121,7 +121,7 @@ public class SkillService {
         }
         if (geminiSkillTagSuggestionClient.isConfigured()) {
             try {
-                List<Skill> catalog = catalogForNlp(textForMatch, allSkills);
+                List<Skill> catalog = catalogForNlp(text, allSkills, koreanAliasEnglishHits);
                 List<GeminiSkillPick> picks = geminiSkillTagSuggestionClient.suggestFromDocument(
                         rawText, context, catalog, topN);
                 if (!picks.isEmpty()) {
@@ -147,13 +147,14 @@ public class SkillService {
                 log.warn("NLP 스킬 추출 실패, 규칙 기반으로 대체: {}", e.getMessage());
             }
         }
-        return heuristicSuggestTagsFromText(textForMatch, allSkills, topN);
+        return heuristicSuggestTagsFromText(text, allSkills, topN, koreanAliasEnglishHits);
     }
 
     /**
      * NLP 프롬프트 길이 제한 — 후보가 많으면 문자열 매칭 점수로 상위만 골라 Gemini에 넘깁니다.
      */
-    private List<Skill> catalogForNlp(String normalizedDoc, List<Skill> allSkills) {
+    private List<Skill> catalogForNlp(String normalizedDoc, List<Skill> allSkills,
+                                      Set<String> koreanAliasEnglishHits) {
         if (allSkills.size() <= NLP_CATALOG_CAP) {
             return allSkills;
         }
@@ -163,7 +164,7 @@ public class SkillService {
             if (skillName.isBlank()) {
                 continue;
             }
-            double score = scoreSkill(normalizedDoc, skillName);
+            double score = scoreSkillForSuggest(normalizedDoc, skillName, koreanAliasEnglishHits);
             if (score > 0) {
                 scored.add(new ScoredSkill(skill, score));
             }
@@ -189,14 +190,15 @@ public class SkillService {
     }
 
     private List<SkillTagSuggestionResponse> heuristicSuggestTagsFromText(
-            String normalizedDoc, List<Skill> allSkills, int topN) {
+            String normalizedDoc, List<Skill> allSkills, int topN,
+            Set<String> koreanAliasEnglishHits) {
         List<ScoredSkill> scored = new ArrayList<>();
         for (Skill skill : allSkills) {
             String skillName = normalize(skill.getName());
             if (skillName.isBlank()) {
                 continue;
             }
-            double score = scoreSkill(normalizedDoc, skillName);
+            double score = scoreSkillForSuggest(normalizedDoc, skillName, koreanAliasEnglishHits);
             if (score > 0) {
                 scored.add(new ScoredSkill(skill, score));
             }
@@ -213,15 +215,15 @@ public class SkillService {
     private static final int SHORT_TOKEN_MAX_LEN = 2;
 
     /**
-     * 기본 스킬 카탈로그가 영문명 위주일 때, 본문의 한글 표기와 매칭되도록 동의어를 뒤에 붙입니다.
-     * (Gemini는 원문 rawText를 그대로 읽고, 이 보강은 휴리스틱·catalogForNlp 전용입니다.)
+     * 본문(정규화)에 등장한 한글 별칭에 대응하는 카탈로그 영문 스킬명(정규화) 집합.
+     * 문서 문자열을 바꾸지 않으며, {@link #scoreSkillForSuggest}에서 해당 스킬과 정확히 일치할 때만 가산합니다.
      */
-    private static String augmentDocumentWithKoreanSkillAliases(String normalizedDoc) {
-        if (normalizedDoc.isBlank()) {
-            return normalizedDoc;
+    private static LinkedHashSet<String> collectKoreanAliasEnglishHits(String normalizedDoc) {
+        LinkedHashSet<String> extras = new LinkedHashSet<>();
+        if (normalizedDoc == null || normalizedDoc.isBlank()) {
+            return extras;
         }
         String compactDoc = compact(normalizedDoc);
-        LinkedHashSet<String> extras = new LinkedHashSet<>();
         for (KrSkillAlias rule : KR_SKILL_ALIASES_SORTED) {
             if (!rule.docGuard().test(normalizedDoc)) {
                 continue;
@@ -237,10 +239,22 @@ public class SkillService {
                 }
             }
         }
-        if (extras.isEmpty()) {
-            return normalizedDoc;
+        return extras;
+    }
+
+    /**
+     * 문서 기반 {@link #scoreSkill}과 한글 별칭으로 유도된 영문 스킬명(정규화) 정확 일치를 합칩니다.
+     * 별칭 일치는 전체 정규화 스킬명이 {@code koreanAliasEnglishHits}에 포함될 때만 1.0을 부여합니다.
+     */
+    private static double scoreSkillForSuggest(String normalizedDoc, String skillNameNormalized,
+                                               Set<String> koreanAliasEnglishHits) {
+        double fromDoc = scoreSkill(normalizedDoc, skillNameNormalized);
+        if (koreanAliasEnglishHits != null
+                && !koreanAliasEnglishHits.isEmpty()
+                && koreanAliasEnglishHits.contains(skillNameNormalized)) {
+            return Math.max(fromDoc, 1.0);
         }
-        return normalizedDoc + " " + String.join(" ", extras);
+        return fromDoc;
     }
 
     private record KrSkillAlias(

--- a/backend/src/test/java/com/devnear/web/service/skill/SkillServiceKoreanAliasHitsTest.java
+++ b/backend/src/test/java/com/devnear/web/service/skill/SkillServiceKoreanAliasHitsTest.java
@@ -1,0 +1,24 @@
+package com.devnear.web.service.skill;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SkillServiceKoreanAliasHitsTest {
+
+    @Test
+    void javascriptWordDoesNotTriggerJavaFromEmbeddedJavaSubstring() {
+        LinkedHashSet<String> hits = SkillService.collectKoreanAliasEnglishHits("자바스크립트");
+        assertFalse(hits.contains("java"), "자바 inside 자바스크립트 must not register Java alias hit");
+        assertTrue(hits.contains("javascript"), "whole-word 자바스크립트 maps to JavaScript");
+    }
+
+    @Test
+    void standaloneJavaKoreanStillRegistersJava() {
+        LinkedHashSet<String> hits = SkillService.collectKoreanAliasEnglishHits("백엔드 자바 스프링");
+        assertTrue(hits.contains("java"));
+    }
+}

--- a/frontend/app/client/mainpage/page.tsx
+++ b/frontend/app/client/mainpage/page.tsx
@@ -9,7 +9,7 @@ import { Search, MapPin, SlidersHorizontal } from 'lucide-react';
 import { motion } from 'framer-motion';
 
 // 🎯 1. 대통합 네비게이션 바 불러오기
-import GlobalNavbar from '@/components/common/GlobalNavbar';
+import GlobalNavbar, { type UserData, type ProfileData } from '@/components/common/GlobalNavbar';
 
 export default function ClientDashboard() {
     const router = useRouter();
@@ -19,10 +19,10 @@ export default function ClientDashboard() {
     const [authorized, setAuthorized] = useState(false);
 
     // 🎯 2. GlobalNavbar에 전달할 유저 정보 상태
-    const [user, setUser] = useState<Record<string, unknown> | null>(null);
+    const [user, setUser] = useState<UserData | null>(null);
 
     // 🎯 [추가] 사진(logoUrl) 데이터를 담을 프로필 상태
-    const [profile, setProfile] = useState<Record<string, unknown> | null>(null);
+    const [profile, setProfile] = useState<ProfileData | null>(null);
 
     const [cursor, setCursor] = useState({ x: 0, y: 0 });
 
@@ -47,7 +47,8 @@ export default function ClientDashboard() {
                 const res = await api.get("/v1/users/me");
 
                 // 🎯 [리뷰 반영] Role 정규화: ROLE_BOTH -> BOTH (GlobalNavbar 대응)
-                const normalizedRole = res.data.role?.replace("ROLE_", "") || "";
+                const raw = res.data as Record<string, unknown>;
+                const normalizedRole = String(raw.role ?? '').replace("ROLE_", "");
 
                 if (normalizedRole === "GUEST") {
                     router.replace("/onboarding");
@@ -60,8 +61,20 @@ export default function ClientDashboard() {
                     return;
                 }
 
-                // 🎯 3. 정규화된 유저 정보 저장
-                setUser({ ...res.data, role: normalizedRole });
+                const navbarRole: UserData['role'] =
+                    normalizedRole === 'BOTH' ? 'BOTH' : 'CLIENT';
+
+                const profileImg =
+                    (typeof raw.profileImage === 'string' ? raw.profileImage : undefined)
+                    ?? (typeof raw.profileImageUrl === 'string' ? raw.profileImageUrl : undefined);
+
+                setUser({
+                    role: navbarRole,
+                    nickname: typeof raw.nickname === 'string' ? raw.nickname : undefined,
+                    name: typeof raw.name === 'string' ? raw.name : undefined,
+                    profileImage: profileImg,
+                    imageUrl: typeof raw.imageUrl === 'string' ? raw.imageUrl : undefined,
+                });
                 setAuthorized(true);
             } catch {
                 router.replace("/login");
@@ -75,7 +88,7 @@ export default function ClientDashboard() {
     useEffect(() => {
         if (authorized) {
             api.get('/client/profile')
-                .then(res => setProfile(res.data))
+                .then(res => setProfile(res.data as ProfileData))
                 .catch(() => {});
         }
     }, [authorized]);

--- a/frontend/app/client/mainpage/page.tsx
+++ b/frontend/app/client/mainpage/page.tsx
@@ -48,21 +48,28 @@ export default function ClientDashboard() {
 
                 // 🎯 [리뷰 반영] Role 정규화: ROLE_BOTH -> BOTH (GlobalNavbar 대응)
                 const raw = res.data as Record<string, unknown>;
-                const normalizedRole = String(raw.role ?? '').replace("ROLE_", "");
+                const normalizedRoles = String(raw.role ?? '')
+                    .split(',')
+                    .map((v) => v.trim().replace(/^ROLE_/, ''))
+                    .filter(Boolean);
 
-                if (normalizedRole === "GUEST") {
+                if (normalizedRoles.includes("GUEST")) {
                     router.replace("/onboarding");
                     return;
                 }
 
-                if (normalizedRole === "FREELANCER") {
+                if (
+                    normalizedRoles.includes("FREELANCER") &&
+                    !normalizedRoles.includes("CLIENT") &&
+                    !normalizedRoles.includes("BOTH")
+                ) {
                     alert("해당 대시보드는 클라이언트 전용 화면입니다.");
                     router.replace("/");
                     return;
                 }
 
                 const navbarRole: UserData['role'] =
-                    normalizedRole === 'BOTH' ? 'BOTH' : 'CLIENT';
+                    normalizedRoles.includes('BOTH') ? 'BOTH' : 'CLIENT';
 
                 const profileImg =
                     (typeof raw.profileImage === 'string' ? raw.profileImage : undefined)

--- a/frontend/app/client/mypage/page.tsx
+++ b/frontend/app/client/mypage/page.tsx
@@ -10,7 +10,7 @@ import api from '../../lib/axios';
 
 import MypageSidebar from '@/components/layout/MypageSidebar';
 // 🎯 [수정 1] 기존 MypageNavbar 임포트 삭제 후 GlobalNavbar 임포트
-import GlobalNavbar from '@/components/common/GlobalNavbar';
+import GlobalNavbar, { type UserData, type ProfileData } from '@/components/common/GlobalNavbar';
 import ProjectsTab from '@/components/client_mypage/ProjectsTab';
 import SettingsTab from '@/components/client_mypage/SettingsTab';
 import BookmarkedFreelancers from '@/components/client_mypage/BookmarkedFreelancers';
@@ -37,6 +37,20 @@ interface ProjectDto {
     skills: string[];
 }
 
+function mapClientMyPageUserToNavbarUser(u: UserProfile): UserData {
+    const r = String(u.role).replace('ROLE_', '');
+    const role: UserData['role'] = r.includes('BOTH')
+        ? 'BOTH'
+        : r.includes('FREELANCER')
+            ? 'FREELANCER'
+            : 'CLIENT';
+    return {
+        role,
+        nickname: u.nickname,
+        name: u.name,
+    };
+}
+
 const TABS = [
     { id: 'settings', label: 'ACCOUNT SETTINGS', icon: UserCircle },
     { id: 'projects', label: 'MY PROJECTS', icon: Briefcase },
@@ -46,7 +60,7 @@ const TABS = [
 export default function ClientMyPage() {
     const router = useRouter();
     const [user, setUser] = useState<UserProfile | null>(null);
-    const [profile, setProfile] = useState<any>(null);
+    const [profile, setProfile] = useState<ProfileData | null>(null);
     const [projects, setProjects] = useState<ProjectDto[]>([]);
     const [loading, setLoading] = useState(true);
     const [authorized, setAuthorized] = useState(false);
@@ -88,7 +102,7 @@ export default function ClientMyPage() {
                     api.get('/client/profile')
                 ]);
                 setProjects(projectsRes.data.content || projectsRes.data || []);
-                setProfile(profileRes.data);
+                setProfile(profileRes.data as ProfileData);
             } catch (err) {
                 console.error("데이터 로드 실패", err);
             } finally {
@@ -128,7 +142,7 @@ export default function ClientMyPage() {
             </div>
 
             {/* 🎯 [2. 수정] 기존 MypageNavbar를 지우고 GlobalNavbar로 대체! (navItems 배열은 삭제해도 되지만 유지했습니다) */}
-            <GlobalNavbar user={user} profile={profile} />
+            <GlobalNavbar user={user ? mapClientMyPageUserToNavbarUser(user) : null} profile={profile} />
 
             <main className="max-w-7xl mx-auto px-6 mt-12 grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-8 items-start relative z-10">
                 <MypageSidebar

--- a/frontend/app/client/mypage/page.tsx
+++ b/frontend/app/client/mypage/page.tsx
@@ -38,12 +38,16 @@ interface ProjectDto {
 }
 
 function mapClientMyPageUserToNavbarUser(u: UserProfile): UserData {
-    const r = String(u.role).replace('ROLE_', '');
-    const role: UserData['role'] = r.includes('BOTH')
-        ? 'BOTH'
-        : r.includes('FREELANCER')
-            ? 'FREELANCER'
-            : 'CLIENT';
+        const roles = String(u.role)
+                .split(',')
+            .map((v) => v.trim().replace(/^ROLE_/, ''))
+            .filter(Boolean);
+        const hasClient = roles.includes('CLIENT');
+        const hasFreelancer = roles.includes('FREELANCER');
+        const role: UserData['role'] =
+                roles.includes('BOTH') || (hasClient && hasFreelancer)
+                    ? 'BOTH'
+                        : 'CLIENT';
     return {
         role,
         nickname: u.nickname,

--- a/frontend/app/client/mypage/page.tsx
+++ b/frontend/app/client/mypage/page.tsx
@@ -39,7 +39,7 @@ interface ProjectDto {
 
 function mapClientMyPageUserToNavbarUser(u: UserProfile): UserData {
         const roles = String(u.role)
-                .split(',')
+            .split(',')
             .map((v) => v.trim().replace(/^ROLE_/, ''))
             .filter(Boolean);
         const hasClient = roles.includes('CLIENT');
@@ -47,7 +47,7 @@ function mapClientMyPageUserToNavbarUser(u: UserProfile): UserData {
         const role: UserData['role'] =
                 roles.includes('BOTH') || (hasClient && hasFreelancer)
                     ? 'BOTH'
-                        : 'CLIENT';
+                    : 'CLIENT';
     return {
         role,
         nickname: u.nickname,

--- a/frontend/app/freelancer/mypage/page.tsx
+++ b/frontend/app/freelancer/mypage/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, Suspense } from 'react';
 import { motion } from 'framer-motion';
 import { User as UserIcon, Briefcase, Star, Award, Bookmark, CreditCard } from 'lucide-react';
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
@@ -41,7 +41,7 @@ const LOCATION_COORDS: Record<string, { lat: number, lng: number }> = {
 
 const EMPTY_PORTFOLIO_FORM = { id: null as number | null | undefined, title: '', desc: '', thumbnailUrl: '', portfolioImages: [] as string[], skills: [] as number[] };
 
-export default function FreelancerMyPage() {
+function FreelancerMyPageContent() {
     const router = useRouter();
     const pathname = usePathname();
     const [activeTab, setActiveTab] = useState('profile');
@@ -379,5 +379,19 @@ export default function FreelancerMyPage() {
             <PortfolioFormModal isOpen={isPortfolioModalOpen} onClose={() => { setIsPortfolioModalOpen(false); setPortfolioForm(EMPTY_PORTFOLIO_FORM); setPortfolioSkillSearchQuery(''); }} portfolioForm={portfolioForm} setPortfolioForm={setPortfolioForm} portfolioSkillSearchQuery={portfolioSkillSearchQuery} setPortfolioSkillSearchQuery={setPortfolioSkillSearchQuery} allGlobalSkills={allGlobalSkills} isThumbUploading={isThumbUploading} isBulkUploading={isBulkUploading} thumbFileInputRef={thumbFileInputRef} bulkFileInputRef={bulkFileInputRef} handleThumbUpload={handleThumbUpload} handleBulkImageUpload={handleBulkImageUpload} removePortfolioImage={removePortfolioImage} togglePortfolioSkill={togglePortfolioSkill} handleSavePortfolio={handleSavePortfolio} />
             <PortfolioDetailModal selectedPortfolio={selectedPortfolio} setSelectedPortfolio={setSelectedPortfolio} activeImageIndex={activeImageIndex} setActiveImageIndex={setActiveImageIndex} handleDeletePortfolio={handleDeletePortfolio} setIsPortfolioModalOpen={setIsPortfolioModalOpen} setPortfolioForm={setPortfolioForm} />
         </div>
+    );
+}
+
+export default function FreelancerMyPage() {
+    return (
+        <Suspense
+            fallback={
+                <div className="flex min-h-screen items-center justify-center bg-zinc-50 text-[#7A4FFF] font-black text-xl animate-pulse">
+                    LOADING...
+                </div>
+            }
+        >
+            <FreelancerMyPageContent />
+        </Suspense>
     );
 }

--- a/frontend/components/common/GlobalNavbar.tsx
+++ b/frontend/components/common/GlobalNavbar.tsx
@@ -8,8 +8,8 @@ import { Search, Plus } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { getActiveRole, setActiveRole } from '@/app/lib/auth';
 
-// 🎯 명확한 인터페이스 정의
-interface UserData {
+// 🎯 명확한 인터페이스 정의 (페이지에서 GlobalNavbar props와 동일하게 맞출 때 import)
+export interface UserData {
     role: 'CLIENT' | 'FREELANCER' | 'BOTH';
     nickname?: string;
     name?: string;
@@ -17,7 +17,7 @@ interface UserData {
     imageUrl?: string;
 }
 
-interface ProfileData {
+export interface ProfileData {
     logoUrl?: string;
     profileImageUrl?: string;
 }


### PR DESCRIPTION
## 🔎 What

- 한 작업을 간단히 설명해주세요

## 🔗 Issue

- Closes: #108 

## ✅ 체크리스트

- [ ] 브랜치 base가 적절한가요?
- [ ] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Demo data expanded: more freelancers, clients, portfolios and projects with per-user distribution and Korean city-based locations with realistic coordinate jitter.
  * Skill suggestion enhanced to recognize Korean skill names and map them to standardized tags.
  * Improved page loading feedback via Suspense-based fallback for freelancer pages.

* **Chores**
  * Stronger runtime typing and multi-role parsing/normalization for user/profile data; navbar types exported for reuse.

* **Tests**
  * Added unit tests validating Korean skill-alias matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->