### PR TITLE
feat: Redis 세션 연동 및 User API N+1

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,6 +31,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'p6spy:p6spy:3.9.1' //api 성능 테스트
+	// Redis 및 캐싱을 위한 필수 라이브러리
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	// Flyway: Hibernate ddl-auto와 스키마 관리 충돌 방지를 위해 비활성화 (필요 시 주석 해제)
 	// implementation 'org.flywaydb:flyway-core'
 	// implementation 'org.flywaydb:flyway-mysql'

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,10 +1,9 @@
-# version: '3.8'
 services:
   db:
     image: mysql:8.0
     container_name: devnear-db
     ports:
-      - "3307:3306"  # 왼쪽 3306을 3307로 바꿉니다!
+      - "3307:3306"
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: devnear
@@ -12,4 +11,11 @@ services:
       MYSQL_PASSWORD: user123
     volumes:
       - ./mysql_data:/var/lib/mysql
+    restart: always
+
+  redis:
+    image: redis:latest
+    container_name: devnear-redis
+    ports:
+      - "6379:6379"
     restart: always

--- a/backend/src/main/java/com/devnear/global/auth/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/devnear/global/auth/CustomUserDetailsService.java
@@ -2,6 +2,7 @@ package com.devnear.global.auth;
 
 import com.devnear.web.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.lang.NonNull;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -15,8 +16,10 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(@NonNull String email) throws UsernameNotFoundException { //@NonNull 추가
+    @Cacheable(value = "users", key = "#email", sync = true) // sync 추가!
+    public UserDetails loadUserByUsername(@NonNull String email) throws UsernameNotFoundException {
         return userRepository.findByEmail(email)
+                .map(SecurityUser::new)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
     }
 }

--- a/backend/src/main/java/com/devnear/global/auth/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/devnear/global/auth/CustomUserDetailsService.java
@@ -19,14 +19,18 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    @Cacheable(value = "users", key = "#email", sync = true) // sync 추가!
+    @Cacheable(value = "users", key = "#email", sync = true)
     public UserDetails loadUserByUsername(@NonNull String email) throws UsernameNotFoundException {
-        return userRepository.findByEmail(email)
-                .map(SecurityUser::new)
+        // 1. 유저를 먼저 찾아서 변수에 담습니다.
+        User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+
+        // 2. 상태를 체크합니다. (UserStatus.WITHDRAWN 체크)
         if (user.getStatus() == UserStatus.WITHDRAWN) {
             throw new DisabledException("탈퇴한 계정입니다.");
         }
-        return user;
+
+        // 3. 마지막에 SecurityUser로 변환하여 반환합니다.
+        return new SecurityUser(user);
     }
 }

--- a/backend/src/main/java/com/devnear/global/auth/LoginUser.java
+++ b/backend/src/main/java/com/devnear/global/auth/LoginUser.java
@@ -1,0 +1,11 @@
+package com.devnear.global.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+}

--- a/backend/src/main/java/com/devnear/global/auth/LoginUserArgumentResolver.java
+++ b/backend/src/main/java/com/devnear/global/auth/LoginUserArgumentResolver.java
@@ -1,0 +1,41 @@
+package com.devnear.global.auth;
+
+import com.devnear.web.domain.user.User;
+import com.devnear.web.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // @LoginUser 어노테이션이 붙어 있고, 파라미터 타입이 User 엔티티인 경우에만 작동!
+        return parameter.hasParameterAnnotation(LoginUser.class)
+                && parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth == null || !(auth.getPrincipal() instanceof SecurityUser principal)) {
+            return null; // 로그인하지 않은 경우
+        }
+
+        // 레디스(SecurityUser)에 저장된 ID로 실제 DB에서 유저 엔티티를 조회!
+        return userRepository.findById(principal.getId()).orElse(null);
+    }
+}

--- a/backend/src/main/java/com/devnear/global/auth/SecurityUser.java
+++ b/backend/src/main/java/com/devnear/global/auth/SecurityUser.java
@@ -1,0 +1,47 @@
+package com.devnear.global.auth;
+
+import com.devnear.web.domain.user.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+@NoArgsConstructor // 역직렬화 필수
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class") // 클래스 정보 강제 포함
+public class SecurityUser implements UserDetails {
+    private Long id;
+    private String email;
+    private String password;
+    private String role;
+    private String status; // 🎯 유저 상태값 (활성화/정지 등) 보관 (프론트 미들웨어에서 필요)
+
+    public SecurityUser(User user) {
+        this.id = user.getId();
+        this.email = user.getEmail();
+        this.password = user.getPassword();
+        this.role = user.getRole().name();
+        this.status = user.getStatus().name();
+    }
+
+    @JsonIgnore // Authorities 객체는 직렬화하지 않고 role 문자열만 저장함 (에러 방지)
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role));
+    }
+
+    @Override public String getPassword() { return password; }
+    @Override public String getUsername() { return email; }
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/backend/src/main/java/com/devnear/global/auth/SecurityUser.java
+++ b/backend/src/main/java/com/devnear/global/auth/SecurityUser.java
@@ -14,15 +14,15 @@ import java.util.Collection;
 import java.util.Collections;
 
 @Getter
-@NoArgsConstructor // 역직렬화 필수
+@NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class") // 클래스 정보 강제 포함
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
 public class SecurityUser implements UserDetails {
     private Long id;
     private String email;
     private String password;
     private String role;
-    private String status; // 🎯 유저 상태값 (활성화/정지 등) 보관 (프론트 미들웨어에서 필요)
+    private String status;
 
     public SecurityUser(User user) {
         this.id = user.getId();
@@ -32,7 +32,7 @@ public class SecurityUser implements UserDetails {
         this.status = user.getStatus().name();
     }
 
-    @JsonIgnore // Authorities 객체는 직렬화하지 않고 role 문자열만 저장함 (에러 방지)
+    @JsonIgnore
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role));
@@ -43,5 +43,11 @@ public class SecurityUser implements UserDetails {
     @Override public boolean isAccountNonExpired() { return true; }
     @Override public boolean isAccountNonLocked() { return true; }
     @Override public boolean isCredentialsNonExpired() { return true; }
-    @Override public boolean isEnabled() { return true; }
+
+    @Override
+    public boolean isEnabled() {
+        // 🎯 [수정] ACTIVE 또는 INACTIVE 상태일 때만 true를 반환
+        // 탈퇴(WITHDRAWN)나 정지 상태라면 false가 반환되어 시큐리티가 차단합
+        return "ACTIVE".equals(status) || "INACTIVE".equals(status);
+    }
 }

--- a/backend/src/main/java/com/devnear/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/devnear/global/config/DataInitializer.java
@@ -1,12 +1,19 @@
 package com.devnear.global.config;
 
+import com.devnear.web.domain.skill.Skill;
 import com.devnear.web.domain.skill.SkillRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.core.annotation.Order;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
 @Component
 @Order(50)
 @RequiredArgsConstructor
@@ -15,20 +22,24 @@ public class DataInitializer implements CommandLineRunner {
     private final SkillRepository skillRepository;
 
     @Override
+    @Transactional // 데이터 일관성을 위해 트랜잭션 안에서 실행하는 것이 타당
     public void run(String... args) throws Exception {
-        // [수정] 리뷰 반영: count() == 0 체크 대신, 개별 스킬 이름을 확인하여 없는 스킬만 추가하는 방식으로 무결성 강화
-        int addedCount = 0;
-        for (var skill : DefaultSkillCatalog.newSkillEntities()) {
-            try {
-                skillRepository.save(skill);
-                addedCount++;
-            } catch (DataIntegrityViolationException ignored) {
-                // already inserted by previous run or concurrent initializer
-            }
-        }
+        // 1. 현재 DB에 저장된 모든 스킬 이름을 한 번에 가져와서 Set에 담음 (조회 쿼리 1번)
+        Set<String> existingSkillNames = skillRepository.findAll().stream()
+                .map(Skill::getName)
+                .collect(Collectors.toSet());
 
-        if (addedCount > 0) {
-            System.out.println("========== [DataInitializer] 기본 스킬 " + addedCount + "개가 새롭게 추가되었습니다! ==========");
+        // 2. 카탈로그의 스킬 중 DB에 없는 '새로운 스킬'만 필터링
+        List<Skill> skillsToInsert = DefaultSkillCatalog.newSkillEntities().stream()
+                .filter(skill -> !existingSkillNames.contains(skill.getName()))
+                .toList();
+
+        // 3. 추가할 스킬이 있는 경우에만 벌크 인서트를 수행 (삽입 쿼리 1번 혹은 0번)
+        if (!skillsToInsert.isEmpty()) {
+            skillRepository.saveAll(skillsToInsert);
+            log.info("========== [DataInitializer] 새로운 기본 스킬 {}개가 추가되었습니다. ==========", skillsToInsert.size());
+        } else {
+            log.info("========== [DataInitializer] 모든 기본 스킬이 이미 최신 상태입니다. ==========");
         }
     }
 }

--- a/backend/src/main/java/com/devnear/global/config/P6SpyConfig.java
+++ b/backend/src/main/java/com/devnear/global/config/P6SpyConfig.java
@@ -4,17 +4,20 @@ import com.p6spy.engine.spy.P6SpyOptions;
 import com.p6spy.engine.spy.appender.StdoutLogger;
 import jakarta.annotation.PostConstruct;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile; // 👈 임포트 추가!
 
 @Configuration
+// 🎯 [수정] prod(운영) 프로파일이 아닐 때만 이 설정을 빈으로 등록
+// local, dev, test 등 개발 환경에서만 작동하
+@Profile("!prod")
 public class P6SpyConfig {
 
     @PostConstruct
     public void setLogMessageFormat() {
-        // 1. 로그 포맷터 설정 (이미 하신 것)
+        // 1. 로그 포맷터 설정
         P6SpyOptions.getActiveInstance().setLogMessageFormat(P6SpyFormatter.class.getName());
 
-        // 2. [필수 추가] 로그 출력 대상을 '콘솔'로 설정합니다.
-        // 이 설정이 없으면 내부적으로 포맷팅만 하고 아무데도 출력하지 않습니다!
+        // 2. 로그 출력 대상을 '콘솔'로 설정
         P6SpyOptions.getActiveInstance().setAppender(StdoutLogger.class.getName());
     }
 }

--- a/backend/src/main/java/com/devnear/global/config/P6SpyConfig.java
+++ b/backend/src/main/java/com/devnear/global/config/P6SpyConfig.java
@@ -1,0 +1,20 @@
+package com.devnear.global.config;
+
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.appender.StdoutLogger;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class P6SpyConfig {
+
+    @PostConstruct
+    public void setLogMessageFormat() {
+        // 1. 로그 포맷터 설정 (이미 하신 것)
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(P6SpyFormatter.class.getName());
+
+        // 2. [필수 추가] 로그 출력 대상을 '콘솔'로 설정합니다.
+        // 이 설정이 없으면 내부적으로 포맷팅만 하고 아무데도 출력하지 않습니다!
+        P6SpyOptions.getActiveInstance().setAppender(StdoutLogger.class.getName());
+    }
+}

--- a/backend/src/main/java/com/devnear/global/config/P6SpyFormatter.java
+++ b/backend/src/main/java/com/devnear/global/config/P6SpyFormatter.java
@@ -1,0 +1,34 @@
+package com.devnear.global.config;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+
+import java.util.Locale;
+
+public class P6SpyFormatter implements MessageFormattingStrategy {
+
+    @Override
+    public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared, String sql, String url) {
+        sql = formatSql(category, sql);
+        if (sql.trim().isEmpty()) return "";
+
+        // 실행 시간(Execution Time)을 ms 단위로 출력하여 성능 모니터링을 돕습니다.
+        return String.format("\n[P6Spy] Execution Time: %d ms | %s", elapsed, sql);
+    }
+
+    private String formatSql(String category, String sql) {
+        if (sql == null || sql.trim().isEmpty()) return "";
+
+        // SQL 문장에 대해 포맷팅을 수행합니다.
+        if (Category.STATEMENT.getName().equals(category)) {
+            String tempSql = sql.trim().toLowerCase(Locale.ROOT);
+            if (tempSql.startsWith("create") || tempSql.startsWith("alter") || tempSql.startsWith("comment")) {
+                return FormatStyle.DDL.getFormatter().format(sql);
+            } else {
+                return FormatStyle.BASIC.getFormatter().format(sql);
+            }
+        }
+        return sql;
+    }
+}

--- a/backend/src/main/java/com/devnear/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/devnear/global/config/RedisConfig.java
@@ -69,6 +69,7 @@ public class RedisConfig {
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(customSerializer));
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(config)
+                .transactionAware()
                 .build();
     }
 }

--- a/backend/src/main/java/com/devnear/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/devnear/global/config/RedisConfig.java
@@ -1,0 +1,68 @@
+package com.devnear.global.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        // 1. 보안과 날짜 처리가 완벽한 ObjectMapper 커스텀 설정
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule()); // 날짜 처리 모듈만 등록 (시큐리티 모듈 제외하여 에러 방지)
+
+        // 역직렬화 시 클래스 타입 보존 (401 에러 방지의 핵심)
+        BasicPolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+                .allowIfBaseType(Object.class)
+                .build();
+        mapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+
+        // 2. [필살기] 지원 중단된 클래스 대신 직접 구현한 무결점 Serializer 사용
+        RedisSerializer<Object> customSerializer = new RedisSerializer<>() {
+            @Override
+            public byte[] serialize(Object value) throws SerializationException {
+                if (value == null) return new byte[0];
+                try {
+                    return mapper.writeValueAsBytes(value);
+                } catch (Exception e) {
+                    throw new SerializationException("직렬화 실패", e);
+                }
+            }
+
+            @Override
+            public Object deserialize(byte[] bytes) throws SerializationException {
+                if (bytes == null || bytes.length == 0) return null;
+                try {
+                    return mapper.readValue(bytes, Object.class);
+                } catch (Exception e) {
+                    throw new SerializationException("역직렬화 실패 (401 원인)", e);
+                }
+            }
+        };
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(RedisSerializer.string()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(customSerializer));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/devnear/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/devnear/global/config/RedisConfig.java
@@ -13,7 +13,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.SerializationException;
-
 import java.time.Duration;
 
 @Configuration
@@ -22,17 +21,22 @@ public class RedisConfig {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-        // 1. 보안과 날짜 처리가 완벽한 ObjectMapper 커스텀 설정
+        // 1. 보안이 강화된 ObjectMapper 설정
         ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule()); // 날짜 처리 모듈만 등록 (시큐리티 모듈 제외하여 에러 방지)
+        mapper.registerModule(new JavaTimeModule());
 
-        // 역직렬화 시 클래스 타입 보존 (401 에러 방지의 핵심)
+        // 🎯 [보안 강화] 모든 클래스(Object.class) 허용은 RCE 공격의 통로가 됨
+        // 우리 프로젝트 내의 클래스와 날짜 관련 타입만 직렬화되도록 화이트리스트를 지정
         BasicPolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
-                .allowIfBaseType(Object.class)
+                .allowIfSubType("com.devnear.") // 우리 패키지 허용
+                .allowIfSubType("java.time.")   // 날짜 타입 허용
+                .allowIfSubType("java.util.")   // 컬렉션 등 허용
+                .allowIfSubType("org.springframework.security.") // 시큐리티 권한 객체 등 허용
                 .build();
+
         mapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
 
-        // 2. [필살기] 지원 중단된 클래스 대신 직접 구현한 무결점 Serializer 사용
+        // 2. 커스텀 Serializer (SecurityUser 등의 DTO 처리에 최적화)
         RedisSerializer<Object> customSerializer = new RedisSerializer<>() {
             @Override
             public byte[] serialize(Object value) throws SerializationException {
@@ -50,14 +54,15 @@ public class RedisConfig {
                 try {
                     return mapper.readValue(bytes, Object.class);
                 } catch (Exception e) {
-                    throw new SerializationException("역직렬화 실패 (401 원인)", e);
+                    throw new SerializationException("역직렬화 실패 (보안 또는 타입 불일치)", e);
                 }
             }
         };
 
+        // 3. 캐시 상세 설정 (TTL 5분 유지)
         RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(10))
-                .disableCachingNullValues()
+                .entryTtl(Duration.ofMinutes(5)) // 짧은 TTL로 데이터 불일치 최소화
+                .disableCachingNullValues()    // 존재하지 않는 유저(Null)는 캐싱하지 않아 DoS 방어
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(RedisSerializer.string()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(customSerializer));
 

--- a/backend/src/main/java/com/devnear/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/devnear/global/config/RedisConfig.java
@@ -52,20 +52,21 @@ public class RedisConfig {
             public Object deserialize(byte[] bytes) throws SerializationException {
                 if (bytes == null || bytes.length == 0) return null;
                 try {
+                    // Object.class로 읽더라도 mapper가 타입 정보를(@class) 보고 타당하게 변환하지만,
+                    // 보안 화이트리스트가 ptv에서 이미 걸러주므로 현재 방식도 안전
                     return mapper.readValue(bytes, Object.class);
                 } catch (Exception e) {
-                    throw new SerializationException("역직렬화 실패 (보안 또는 타입 불일치)", e);
+                    throw new SerializationException("역직렬화 실패: 데이터 구조가 바뀌었을 수 있습니다.", e);
                 }
             }
         };
 
-        // 3. 캐시 상세 설정 (TTL 5분 유지)
+// 3. 캐시 상세 설정
         RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(5)) // 짧은 TTL로 데이터 불일치 최소화
-                .disableCachingNullValues()    // 존재하지 않는 유저(Null)는 캐싱하지 않아 DoS 방어
+                .entryTtl(Duration.ofMinutes(5))
+                // .disableCachingNullValues() // 👈 [고민 포인트]
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(RedisSerializer.string()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(customSerializer));
-
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(config)
                 .build();

--- a/backend/src/main/java/com/devnear/global/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/devnear/global/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.devnear.global.config; // 패키지는 마스터의 환경에 맞게 조정하세요!
+
+import com.devnear.global.auth.LoginUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserArgumentResolver);
+    }
+}

--- a/backend/src/main/java/com/devnear/web/controller/TestController.java
+++ b/backend/src/main/java/com/devnear/web/controller/TestController.java
@@ -1,6 +1,7 @@
 package com.devnear.web.controller;
 
 import com.devnear.web.domain.user.User;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,7 +16,7 @@ public class TestController {
      * SecurityConfig의 .anyRequest().authenticated()에 의해 로그인만 하면 누구나 접근 가능
      */
     @GetMapping("/api/test-data")
-    public Map<String, Object> testData(@AuthenticationPrincipal User user) {
+    public Map<String, Object> testData(@LoginUser User user) {
         return getResponse(user, "보안 확인 및 공통 데이터 로드 성공ㅊㅋ");
     }
 
@@ -24,7 +25,7 @@ public class TestController {
      * SecurityConfig의 .hasAnyRole("FREELANCER", "BOTH") 적용 확인용
      */
     @GetMapping("/api/freelancer/test")
-    public Map<String, Object> freelancerOnly(@AuthenticationPrincipal User user) {
+    public Map<String, Object> freelancerOnly(@LoginUser User user) {
         return getResponse(user, "프리랜서(또는 겸업자) 전용 구역 통과ㅊㅋ");
     }
 
@@ -33,7 +34,7 @@ public class TestController {
      * SecurityConfig의 .hasAnyRole("CLIENT", "BOTH") 적용 확인용
      */
     @GetMapping("/api/client/test")
-    public Map<String, Object> clientOnly(@AuthenticationPrincipal User user) {
+    public Map<String, Object> clientOnly(@LoginUser User user) {
         return getResponse(user, "클라이언트(또는 겸업자) 전용 구역 통과ㅊㅋ");
     }
 

--- a/backend/src/main/java/com/devnear/web/controller/application/ApplicationController.java
+++ b/backend/src/main/java/com/devnear/web/controller/application/ApplicationController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,7 +33,7 @@ public class ApplicationController {
     @Operation(summary = "프로젝트 지원", description = "프리랜서가 프로젝트에 지원하며, 지원 시점 기술 스택 기준 매칭률을 저장합니다.")
     @PostMapping("/applications")
     public ResponseEntity<Map<String, Long>> applyToProject(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @Valid @RequestBody ApplicationRequest request) {
 
         if (user == null) {
@@ -54,7 +55,7 @@ public class ApplicationController {
     @Operation(summary = "내 지원 내역 조회", description = "프리랜서 본인의 프로젝트 지원 내역을 최신순으로 조회합니다.")
     @GetMapping("/applications/me")
     public ResponseEntity<List<MyApplicationResponse>> getMyApplications(
-            @AuthenticationPrincipal User user) {
+            @LoginUser User user) {
 
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
@@ -74,7 +75,7 @@ public class ApplicationController {
     @Operation(summary = "내 프로젝트 지원자 조회", description = "클라이언트가 자신의 프로젝트 지원자 목록을 매칭률 내림차순으로 조회합니다.")
     @GetMapping("/projects/{projectId}/applications")
     public ResponseEntity<List<ApplicantResponse>> getApplicantsForMyProject(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long projectId) {
 
         if (user == null) {
@@ -91,7 +92,7 @@ public class ApplicationController {
     @Operation(summary = "지원 상태 변경", description = "클라이언트가 지원 상태를 ACCEPTED 또는 REJECTED로 변경합니다.")
     @PatchMapping("/applications/{applicationId}/status")
     public ResponseEntity<Void> updateApplicationStatus(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long applicationId,
             @Valid @RequestBody ApplicationStatusUpdateRequest request) {
 

--- a/backend/src/main/java/com/devnear/web/controller/bookmark/BookmarkController.java
+++ b/backend/src/main/java/com/devnear/web/controller/bookmark/BookmarkController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,7 +30,7 @@ public class BookmarkController {
     @Operation(summary = "프리랜서 찜 추가", description = "클라이언트가 프리랜서를 찜합니다.")
     @PostMapping("/freelancers/{freelancerProfileId}")
     public ResponseEntity<Void> addFreelancerBookmark(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long freelancerProfileId) {
         bookmarkService.addFreelancerBookmark(user, freelancerProfileId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -38,7 +39,7 @@ public class BookmarkController {
     @Operation(summary = "프리랜서 찜 삭제")
     @DeleteMapping("/freelancers/{freelancerProfileId}")
     public ResponseEntity<Void> removeFreelancerBookmark(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long freelancerProfileId) {
         bookmarkService.removeFreelancerBookmark(user, freelancerProfileId);
         return ResponseEntity.noContent().build();
@@ -47,7 +48,7 @@ public class BookmarkController {
     @Operation(summary = "찜한 프리랜서 목록 조회")
     @GetMapping("/freelancers")
     public ResponseEntity<Page<FreelancerProfileResponse>> getBookmarkedFreelancers(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(bookmarkService.getBookmarkedFreelancers(user, pageable));
     }
@@ -57,7 +58,7 @@ public class BookmarkController {
     @Operation(summary = "프로젝트 찜 추가", description = "프리랜서가 프로젝트를 찜합니다.")
     @PostMapping("/projects/{projectId}")
     public ResponseEntity<Void> addProjectBookmark(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long projectId) {
         bookmarkService.addProjectBookmark(user, projectId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -66,7 +67,7 @@ public class BookmarkController {
     @Operation(summary = "프로젝트 찜 삭제")
     @DeleteMapping("/projects/{projectId}")
     public ResponseEntity<Void> removeProjectBookmark(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long projectId) {
         bookmarkService.removeProjectBookmark(user, projectId);
         return ResponseEntity.noContent().build();
@@ -75,7 +76,7 @@ public class BookmarkController {
     @Operation(summary = "찜한 프로젝트 목록 조회")
     @GetMapping("/projects")
     public ResponseEntity<Page<ProjectResponse>> getBookmarkedProjects(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(bookmarkService.getBookmarkedProjects(user, pageable));
     }
@@ -85,7 +86,7 @@ public class BookmarkController {
     @Operation(summary = "포트폴리오 좋아요", description = "포트폴리오 작성자를 찜합니다.")
     @PostMapping("/portfolios/{portfolioId}/like")
     public ResponseEntity<Void> likePortfolio(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long portfolioId) {
         bookmarkService.likePortfolio(user, portfolioId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -94,7 +95,7 @@ public class BookmarkController {
     @Operation(summary = "포트폴리오 좋아요 취소", description = "포트폴리오 작성자 찜을 취소합니다.")
     @DeleteMapping("/portfolios/{portfolioId}/like")
     public ResponseEntity<Void> unlikePortfolio(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long portfolioId) {
         bookmarkService.unlikePortfolio(user, portfolioId);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/devnear/web/controller/chat/ChatController.java
+++ b/backend/src/main/java/com/devnear/web/controller/chat/ChatController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,7 +31,7 @@ public class ChatController {
     @Operation(summary = "채팅방 생성", description = "프로젝트 기준 1대1 채팅방을 생성하거나 기존 방을 반환합니다.")
     @PostMapping("/rooms")
     public ResponseEntity<ChatRoomResponse> createRoom(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @RequestBody @Valid ChatRoomCreateRequest request
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -41,7 +42,7 @@ public class ChatController {
     @Operation(summary = "내 채팅방 목록 조회")
     @GetMapping("/rooms")
     public ResponseEntity<List<ChatRoomListResponse>> getMyRooms(
-            @AuthenticationPrincipal User user
+            @LoginUser User user
     ) {
         return ResponseEntity.ok(chatService.getMyRooms(user));
     }
@@ -50,7 +51,7 @@ public class ChatController {
     @Operation(summary = "채팅 메시지 조회")
     @GetMapping("/rooms/{roomId}/messages")
     public ResponseEntity<List<ChatMessageResponse>> getMessages(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long roomId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "50") int size
@@ -65,7 +66,7 @@ public class ChatController {
     @Operation(summary = "읽음 처리")
     @PatchMapping("/rooms/{roomId}/read")
     public ResponseEntity<Void> markAsRead(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long roomId
     ) {
         chatService.markAsRead(user, roomId);

--- a/backend/src/main/java/com/devnear/web/controller/client/ClientController.java
+++ b/backend/src/main/java/com/devnear/web/controller/client/ClientController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,7 +25,7 @@ public class ClientController {
     @Operation(summary = "클라이언트 프로필 등록", description = "로그인한 유저의 기업/의뢰인 정보를 등록합니다.")
     @PostMapping("/profile")
     public ResponseEntity<Long> registerProfile(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @RequestBody @Valid ClientProfileRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(clientService.registerProfile(user, request)); // email 대신 user 직접 전달
@@ -33,14 +34,14 @@ public class ClientController {
     @Operation(summary = "클라이언트 프로필 조회", description = "로그인한 유저 본인의 기업 프로필 정보를 가져옵니다.")
     @GetMapping("/profile")
     public ResponseEntity<ClientProfileResponse> getMyProfile(
-            @AuthenticationPrincipal User user) {
+            @LoginUser User user) {
         return ResponseEntity.ok(clientService.getMyProfile(user));
     }
 
     @Operation(summary = "클라이언트 프로필 수정", description = "로그인한 유저 본인의 기업 정보를 수정합니다.")
     @PutMapping("/profile")
     public ResponseEntity<Void> updateProfile(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @RequestBody @Valid ClientProfileRequest request) {
         clientService.updateProfile(user, request);
         return ResponseEntity.ok().build();
@@ -49,7 +50,7 @@ public class ClientController {
     @Operation(summary = "클라이언트 프로필 삭제", description = "로그인한 유저의 클라이언트 프로필 정보를 삭제합니다.")
     @DeleteMapping("/profile")
     public ResponseEntity<Void> deleteProfile(
-            @AuthenticationPrincipal User user) {
+            @LoginUser User user) {
         clientService.deleteProfile(user);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/devnear/web/controller/community/CommunityCommentController.java
+++ b/backend/src/main/java/com/devnear/web/controller/community/CommunityCommentController.java
@@ -9,6 +9,7 @@ import com.devnear.web.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,7 +23,7 @@ public class CommunityCommentController {
 
     @PostMapping("/api/community/comments")
     public ResponseEntity<Long> create(@RequestBody CommunityCommentCreateRequest request,
-                                       @AuthenticationPrincipal User user) {
+                                       @LoginUser User user) {
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
@@ -40,7 +41,7 @@ public class CommunityCommentController {
     @PutMapping("/api/community/comments/{commentId}")
     public ResponseEntity<CommunitySuccessResponse> update(@PathVariable Long commentId,
                                                            @RequestBody CommunityCommentUpdateRequest request,
-                                                           @AuthenticationPrincipal User user) {
+                                                           @LoginUser User user) {
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
@@ -52,7 +53,7 @@ public class CommunityCommentController {
 
     @DeleteMapping("/api/community/comments/{commentId}")
     public ResponseEntity<CommunitySuccessResponse> delete(@PathVariable Long commentId,
-                                                           @AuthenticationPrincipal User user) {
+                                                           @LoginUser User user) {
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }

--- a/backend/src/main/java/com/devnear/web/controller/community/CommunityPostController.java
+++ b/backend/src/main/java/com/devnear/web/controller/community/CommunityPostController.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,7 +21,7 @@ public class CommunityPostController {
 
     @PostMapping
     public ResponseEntity<Long> create(@RequestBody CommunityPostCreateRequest request,
-                                       @AuthenticationPrincipal User user) {
+                                       @LoginUser User user) {
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
@@ -42,7 +43,7 @@ public class CommunityPostController {
 
     @GetMapping("/{postId}")
     public ResponseEntity<CommunityPostResponse> findById(@PathVariable Long postId,
-                                                          @AuthenticationPrincipal User user) {
+                                                          @LoginUser User user) {
         Long userId = (user != null) ? user.getId() : null;
         return ResponseEntity.ok(communityPostService.findById(postId, userId));
     }
@@ -50,7 +51,7 @@ public class CommunityPostController {
     @PutMapping("/{postId}")
     public ResponseEntity<CommunitySuccessResponse> update(@PathVariable Long postId,
                                                            @RequestBody CommunityPostUpdateRequest request,
-                                                           @AuthenticationPrincipal User user) {
+                                                           @LoginUser User user) {
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
@@ -62,7 +63,7 @@ public class CommunityPostController {
 
     @DeleteMapping("/{postId}")
     public ResponseEntity<CommunitySuccessResponse> delete(@PathVariable Long postId,
-                                                           @AuthenticationPrincipal User user) {
+                                                           @LoginUser User user) {
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
@@ -74,7 +75,7 @@ public class CommunityPostController {
 
     @PostMapping("/{postId}/like")
     public ResponseEntity<CommunityLikeResponse> like(@PathVariable Long postId,
-                                                      @AuthenticationPrincipal User user) {
+                                                      @LoginUser User user) {
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
@@ -85,7 +86,7 @@ public class CommunityPostController {
 
     @DeleteMapping("/{postId}/like")
     public ResponseEntity<CommunityLikeResponse> cancelLike(@PathVariable Long postId,
-                                                            @AuthenticationPrincipal User user) {
+                                                            @LoginUser User user) {
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }

--- a/backend/src/main/java/com/devnear/web/controller/freelancer/FreelancerController.java
+++ b/backend/src/main/java/com/devnear/web/controller/freelancer/FreelancerController.java
@@ -8,6 +8,7 @@ import com.devnear.web.service.ai.AiRecommendationService;
 import com.devnear.web.service.freelancer.FreelancerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,7 +31,7 @@ public class FreelancerController {
     // [조회] 대시보드 내 프로필 요약 정보 로드
     @GetMapping("/me")
     public ResponseEntity<FreelancerProfileResponse> getMyProfile(
-            @AuthenticationPrincipal User user) {
+            @LoginUser User user) {
 
         if (user == null) {
             return org.springframework.http.ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED)
@@ -49,7 +50,7 @@ public class FreelancerController {
     // [수정] 대시보드 내 프로필 일괄 업데이트
     @PutMapping("/me")
     public ResponseEntity<FreelancerProfileResponse> updateMyProfile(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @Valid @RequestBody FreelancerProfileRequest request) {
 
         if (user == null) {
@@ -97,7 +98,7 @@ public class FreelancerController {
     // [수정] 대시보드 상단 '활동 상태' 단독 토글
     @PatchMapping("/status")
     public ResponseEntity<Map<String, String>> updateMyStatus(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @Valid @RequestBody com.devnear.web.dto.freelancer.FreelancerStatusRequest request) {
 
         if (user == null) {
@@ -112,7 +113,7 @@ public class FreelancerController {
     // [삭제] 내 프리랜서 프로필 삭제
     @DeleteMapping("/me")
     public ResponseEntity<Void> deleteMyProfile(
-            @AuthenticationPrincipal User user) {
+            @LoginUser User user) {
 
         if (user == null) {
             return org.springframework.http.ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();

--- a/backend/src/main/java/com/devnear/web/controller/freelancer/FreelancerSelfController.java
+++ b/backend/src/main/java/com/devnear/web/controller/freelancer/FreelancerSelfController.java
@@ -9,6 +9,7 @@ import com.devnear.web.service.ai.AiRecommendationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,7 +31,7 @@ public class FreelancerSelfController {
 
     @GetMapping("/me/recommended-projects")
     public ResponseEntity<List<RecommendedProjectResponse>> getMyRecommendedProjects(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @RequestParam(required = false) Integer limit) {
 
         if (user == null) {

--- a/backend/src/main/java/com/devnear/web/controller/image/ImageController.java
+++ b/backend/src/main/java/com/devnear/web/controller/image/ImageController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -50,7 +51,7 @@ public class ImageController {
                              "반환된 URL을 포트폴리오 등록/수정 API의 요청 바디에 사용하세요.")
     @PostMapping(value = "/portfolio", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ImageUploadResponse.Single> uploadPortfolioImage(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @RequestPart("file") MultipartFile file) {
 
         requireAuthenticated(user);
@@ -72,7 +73,7 @@ public class ImageController {
                description = "이미지 여러 장(최대 10장)을 Cloudinary에 업로드하고 URL 목록을 반환합니다.")
     @PostMapping(value = "/portfolios/bulk", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ImageUploadResponse.Multi> uploadPortfolioImages(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @RequestPart("files") List<MultipartFile> files) {
 
         requireAuthenticated(user);
@@ -99,7 +100,7 @@ public class ImageController {
                description = "프로필 이미지를 Cloudinary에 업로드하고 즉시 내 계정에 반영합니다.")
     @PostMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ImageUploadResponse.Single> uploadProfileImage(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @RequestPart("file") MultipartFile file) {
 
         requireAuthenticated(user);

--- a/backend/src/main/java/com/devnear/web/controller/notification/NotificationController.java
+++ b/backend/src/main/java/com/devnear/web/controller/notification/NotificationController.java
@@ -1,6 +1,6 @@
 package com.devnear.web.controller.notification;
 
-import com.devnear.web.domain.user.User;
+import com.devnear.global.auth.SecurityUser; // [중요] SecurityUser 임포트
 import com.devnear.web.dto.notification.NotificationInboxResponse;
 import com.devnear.web.service.notification.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,12 +9,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Notification", description = "알림 조회 및 읽음 처리")
 @RestController
@@ -27,19 +24,21 @@ public class NotificationController {
     @Operation(summary = "내 알림 목록", description = "최신순 페이지와 미읽음 개수를 반환합니다.")
     @GetMapping
     public ResponseEntity<NotificationInboxResponse> list(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal SecurityUser principal, // [수정] User -> SecurityUser
             @PageableDefault(size = 20) Pageable pageable
     ) {
-        return ResponseEntity.ok(notificationService.getInbox(user, pageable));
+        // [수정] principal.getId()만 넘겨줍니다.
+        return ResponseEntity.ok(notificationService.getInbox(principal.getId(), pageable));
     }
 
     @Operation(summary = "알림 읽음 처리", description = "본인 알림만 읽음으로 표시합니다.")
     @PatchMapping("/{notificationId}/read")
     public ResponseEntity<Void> markRead(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal SecurityUser principal, // [수정] User -> SecurityUser
             @PathVariable Long notificationId
     ) {
-        notificationService.markNotificationRead(user, notificationId);
+        // [수정] principal.getId()만 넘겨줍니다.
+        notificationService.markNotificationRead(principal.getId(), notificationId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/devnear/web/controller/portfolio/PortfolioController.java
+++ b/backend/src/main/java/com/devnear/web/controller/portfolio/PortfolioController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,7 +25,7 @@ public class PortfolioController {
     // [등록] POST /api/portfolios
     @PostMapping
     public ResponseEntity<Map<String, Long>> createPortfolio(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @Valid @RequestBody PortfolioRequest request) {
 
         // 로그인 안 된 상태 차단 (401 방어막)
@@ -48,7 +49,7 @@ public class PortfolioController {
     // [삭제] DELETE /api/portfolios/{id}
     @DeleteMapping("/{id}")
     public ResponseEntity<Map<String, Boolean>> deletePortfolio(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable("id") Long id) {
 
         // 로그인 안 된 상태 차단 (401 방어막)
@@ -63,7 +64,7 @@ public class PortfolioController {
     // [수정] PUT /api/portfolios/{id}
     @PutMapping("/{id}")
     public ResponseEntity<Map<String, Boolean>> updatePortfolio(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable("id") Long id,
             @Valid @RequestBody PortfolioRequest request) {
 
@@ -78,7 +79,7 @@ public class PortfolioController {
     // [내 포트폴리오 조회] GET /api/portfolios/me
     @GetMapping("/me")
     public ResponseEntity<List<PortfolioResponse>> getMyPortfolios(
-            @AuthenticationPrincipal User user) {
+            @LoginUser User user) {
 
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();

--- a/backend/src/main/java/com/devnear/web/controller/project/ProjectController.java
+++ b/backend/src/main/java/com/devnear/web/controller/project/ProjectController.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,7 +32,7 @@ public class ProjectController {
     @Operation(summary = "프로젝트 공고 등록", description = "클라이언트가 새로운 프로젝트 공고를 등록합니다.")
     @PostMapping
     public ResponseEntity<Long> createProject(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @RequestBody @Valid ProjectRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(projectService.createProject(user, request));
@@ -40,7 +41,7 @@ public class ProjectController {
     @Operation(summary = "프로젝트 공고 수정", description = "본인이 등록한 프로젝트 공고 내용을 수정합니다.")
     @PutMapping("/{projectId}")
     public ResponseEntity<Void> updateProject(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long projectId,
             @RequestBody @Valid ProjectRequest request) {
         projectService.updateProject(user, projectId, request);
@@ -50,7 +51,7 @@ public class ProjectController {
     @Operation(summary = "프로젝트 공고 삭제", description = "본인이 등록한 프로젝트 공고를 삭제합니다.")
     @DeleteMapping("/{projectId}")
     public ResponseEntity<Void> deleteProject(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long projectId) {
         projectService.deleteProject(user, projectId);
         return ResponseEntity.noContent().build();
@@ -65,7 +66,7 @@ public class ProjectController {
     )
     @GetMapping
     public ResponseEntity<Page<ProjectResponse>> getProjectList(
-            @Nullable @AuthenticationPrincipal(errorOnInvalidType = false) User viewer,
+            @Nullable @LoginUser User viewer,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String location,
             @RequestParam(required = false) String skill,
@@ -106,7 +107,7 @@ public class ProjectController {
     @Operation(summary = "내 프로젝트 목록 조회", description = "로그인한 유저가 작성한 프로젝트 공고만 조회합니다.")
     @GetMapping("/me")
     public ResponseEntity<Page<ProjectResponse>> getMyProjects(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @RequestParam(required = false) ProjectStatus status,  // 추가
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(projectService.getMyProjectList(user, status, pageable));
@@ -122,7 +123,7 @@ public class ProjectController {
     @Operation(summary = "프로젝트 마감", description = "프로젝트 공고를 마감합니다.")
     @PatchMapping("/{projectId}/close")
     public ResponseEntity<Void> closeProject(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long projectId) {
         projectService.closeProject(user, projectId);
         return ResponseEntity.ok().build();
@@ -131,7 +132,7 @@ public class ProjectController {
     @Operation(summary = "프로젝트 시작", description = "프로젝트를 진행중으로 변경합니다.")
     @PatchMapping("/{projectId}/start")
     public ResponseEntity<Void> startProject(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long projectId) {
         projectService.startProject(user, projectId);
         return ResponseEntity.ok().build();
@@ -140,7 +141,7 @@ public class ProjectController {
     @Operation(summary = "프로젝트 완료", description = "프로젝트를 완료 처리합니다.")
     @PatchMapping("/{projectId}/complete")
     public ResponseEntity<Void> completeProject(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long projectId) {
         projectService.completeProject(user, projectId);
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/devnear/web/controller/proposal/ProposalController.java
+++ b/backend/src/main/java/com/devnear/web/controller/proposal/ProposalController.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,7 +35,7 @@ public class ProposalController {
     @Operation(summary = "역제안 전송", description = "클라이언트가 특정 프리랜서에게 역제안(스카우트)을 보냅니다.")
     @PostMapping
     public ResponseEntity<Map<String, Long>> sendProposal(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @Valid @RequestBody ProposalRequest request) {
 
         if (user == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
@@ -53,7 +54,7 @@ public class ProposalController {
     @Operation(summary = "역제안 전송(제안서 전용 프로젝트 동시 생성)", description = "프로젝트 공고를 생성하고 같은 요청에서 역제안을 보냅니다.")
     @PostMapping("/with-standalone-project")
     public ResponseEntity<Map<String, Long>> sendProposalWithStandaloneProject(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @Valid @RequestBody ProposalWithStandaloneProjectRequest request) {
 
         if (user == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
@@ -72,7 +73,7 @@ public class ProposalController {
     @Operation(summary = "보낸 역제안 목록 조회", description = "클라이언트가 자신이 보낸 역제안 목록을 최신순으로 조회합니다.")
     @GetMapping("/sent")
     public ResponseEntity<List<SentProposalResponse>> getSentProposals(
-            @AuthenticationPrincipal User user) {
+            @LoginUser User user) {
 
         if (user == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 
@@ -86,7 +87,7 @@ public class ProposalController {
     @Operation(summary = "받은 역제안 목록 조회", description = "프리랜서가 자신이 받은 역제안 목록을 최신순으로 조회합니다.")
     @GetMapping("/received")
     public ResponseEntity<List<ReceivedProposalResponse>> getReceivedProposals(
-            @AuthenticationPrincipal User user) {
+            @LoginUser User user) {
 
         if (user == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 
@@ -100,7 +101,7 @@ public class ProposalController {
     @Operation(summary = "역제안 수락/거절", description = "프리랜서가 받은 역제안을 ACCEPTED 또는 REJECTED로 변경합니다.")
     @PatchMapping("/{proposalId}/status")
     public ResponseEntity<Void> respondToProposal(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long proposalId,
             @Valid @RequestBody ProposalStatusUpdateRequest request) {
 
@@ -120,7 +121,7 @@ public class ProposalController {
     @Operation(summary = "역제안 문의하기", description = "프리랜서가 받은 역제안 기준으로 채팅방을 조회하거나 생성합니다.")
     @PostMapping("/{proposalId}/inquire")
     public ResponseEntity<ProposalInquiryResponse> inquire(
-            @AuthenticationPrincipal User user,
+            @LoginUser User user,
             @PathVariable Long proposalId
     ) {
         if (user == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();

--- a/backend/src/main/java/com/devnear/web/controller/review/ReviewController.java
+++ b/backend/src/main/java/com/devnear/web/controller/review/ReviewController.java
@@ -8,6 +8,7 @@ import com.devnear.web.service.review.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,7 +22,7 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping("/freelancers")
-    public ResponseEntity<Long> createFreelancerReview(@AuthenticationPrincipal User user,
+    public ResponseEntity<Long> createFreelancerReview(@LoginUser User user,
                                                        @RequestBody FreelancerReviewCreateRequest request) {
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
@@ -32,7 +33,7 @@ public class ReviewController {
     }
 
     @PostMapping("/clients")
-    public ResponseEntity<Long> createClientReview(@AuthenticationPrincipal User user,
+    public ResponseEntity<Long> createClientReview(@LoginUser User user,
                                                    @RequestBody ClientReviewCreateRequest request) {
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();

--- a/backend/src/main/java/com/devnear/web/controller/user/UserController.java
+++ b/backend/src/main/java/com/devnear/web/controller/user/UserController.java
@@ -3,22 +3,16 @@ package com.devnear.web.controller.user;
 import com.devnear.web.dto.user.OnboardingRequest;
 import com.devnear.web.dto.user.TokenResponse;
 import com.devnear.web.dto.user.UserInfoResponse;
-// 기존 임포트들 사이에 추가!
 import com.devnear.web.domain.user.User;
 import com.devnear.web.service.user.UserService;
+import com.devnear.global.auth.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus; 
 import org.springframework.http.ResponseEntity;
-import com.devnear.global.auth.LoginUser;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User", description = "회원 관련 API")
 @RestController
@@ -31,19 +25,27 @@ public class UserController {
     @Operation(summary = "온보딩 처리", description = "GUEST 유저가 닉네임과 역할을 선택하여 권한을 승격합니다.")
     @PostMapping("/onboarding")
     public ResponseEntity<TokenResponse> onboarding(
-            @LoginUser User user, // 👈 [수정] UserDetails -> User
+            @LoginUser User user,
             @RequestBody @Valid OnboardingRequest request) {
 
-        // user.getEmail() 혹은 user.getId()를 바로 쓸 수 있습니다!
+        // 🎯 [수정] 로그인이 안 된 상태라면 NPE 대신 401을 반환
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
         TokenResponse response = userService.onboarding(user.getEmail(), request);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 정보를 조회합니다.")
     @GetMapping("/me")
-    public ResponseEntity<UserInfoResponse> getMyInfo(@LoginUser User user) { // 👈 [수정] UserDetails -> User
+    public ResponseEntity<UserInfoResponse> getMyInfo(@LoginUser User user) {
 
-        // 이제 user는 진짜 DB에서 불러온 엔티티입니다! ㅋㅋㅋ
+        // 🎯 [수정] 로그인이 안 된 상태라면 NPE 대신 401을 반환
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
         UserInfoResponse response = userService.getUserInfo(user.getEmail());
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/devnear/web/controller/user/UserController.java
+++ b/backend/src/main/java/com/devnear/web/controller/user/UserController.java
@@ -3,12 +3,15 @@ package com.devnear.web.controller.user;
 import com.devnear.web.dto.user.OnboardingRequest;
 import com.devnear.web.dto.user.TokenResponse;
 import com.devnear.web.dto.user.UserInfoResponse;
+// 기존 임포트들 사이에 추가!
+import com.devnear.web.domain.user.User;
 import com.devnear.web.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import com.devnear.global.auth.LoginUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,18 +31,20 @@ public class UserController {
     @Operation(summary = "온보딩 처리", description = "GUEST 유저가 닉네임과 역할을 선택하여 권한을 승격합니다.")
     @PostMapping("/onboarding")
     public ResponseEntity<TokenResponse> onboarding(
-            @AuthenticationPrincipal UserDetails userDetails,
+            @LoginUser User user, // 👈 [수정] UserDetails -> User
             @RequestBody @Valid OnboardingRequest request) {
-        
-        // [보고] UserService를 통해 DB 업데이트 및 새 JWT 토큰(권한 승격됨)을 발급받아 반환합니다.
-        TokenResponse response = userService.onboarding(userDetails.getUsername(), request);
+
+        // user.getEmail() 혹은 user.getId()를 바로 쓸 수 있습니다!
+        TokenResponse response = userService.onboarding(user.getEmail(), request);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 정보를 조회합니다.")
     @GetMapping("/me")
-    public ResponseEntity<UserInfoResponse> getMyInfo(@AuthenticationPrincipal UserDetails userDetails) {
-        UserInfoResponse response = userService.getUserInfo(userDetails.getUsername());
+    public ResponseEntity<UserInfoResponse> getMyInfo(@LoginUser User user) { // 👈 [수정] UserDetails -> User
+
+        // 이제 user는 진짜 DB에서 불러온 엔티티입니다! ㅋㅋㅋ
+        UserInfoResponse response = userService.getUserInfo(user.getEmail());
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/devnear/web/domain/user/UserRepository.java
+++ b/backend/src/main/java/com/devnear/web/domain/user/UserRepository.java
@@ -1,15 +1,22 @@
 package com.devnear.web.domain.user;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    // 이메일로 가입된 회원이 있는지 찾는 기능 (로그인/중복체크용)
+
+    /**
+     * [N+1 해결 버전] 이메일로 회원을 조회합니다.
+     * @EntityGraph를 사용하여 연관된 프로필들을 한 번의 LEFT JOIN으로 함께 가져옵니다.
+     * 이로 인해 '유저 조회 1번 + 프로필 조회 N번'이 나가는 현상을 원천 차단합니다.
+     */
+    @EntityGraph(attributePaths = {"freelancerProfile", "clientProfile"})
     Optional<User> findByEmail(String email);
 
     // 닉네임 중복 체크용
     boolean existsByNickname(String nickname);
-    
+
     // 특정 유저 ID를 제외하고 닉네임 중복 체크용
     boolean existsByNicknameAndIdNot(String nickname, Long id);
 }

--- a/backend/src/main/java/com/devnear/web/service/auth/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/devnear/web/service/auth/CustomOAuth2UserService.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
@@ -28,26 +27,18 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     @Override
     @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        // 1. 구글로부터 유저 기본 정보(Attributes)를 가져옴
         OAuth2User oAuth2User = super.loadUser(userRequest);
-
-        // 2. 현재 로그인 진행 중인 서비스 구분 (google, kakao 등)
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
-
-        // 3. OAuth2 로그인 진행 시 키가 되는 필드값 (구글은 기본적으로 "sub"가 PK 역할)
         String userNameAttributeName = userRequest.getClientRegistration()
                 .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
 
-        // 4. 구글이 준 유저 정보를 우리 DB에 맞게 저장하거나 업데이트함
-        Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes()); // 수정 가능하게 복사
+        Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes());
         User user = saveOrUpdate(registrationId, attributes);
 
-        // [보고] 봇 리뷰 반영: 토큰을 발급하는 SuccessHandler로 가기 전에, 유저 상태를 먼저 확인하여 입구 컷
         if (!user.isEnabled()) {
-            throw new InternalAuthenticationServiceException("접근이 차단된 계정입니다. (상태: " + user.getStatus() + ")");
+            throw new InternalAuthenticationServiceException("접근이 차단된 계정입니다.");
         }
 
-        // [보고] 핸들러에서 꺼내 쓸 수 있게 DB PK(id)와 상태(status)를 attributes에 추가함
         attributes.put("id", user.getId());
         attributes.put("status", user.getStatus().name());
 
@@ -64,26 +55,29 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String picture = (String) attributes.get("picture");
         String sub = (String) attributes.get("sub");
 
-        if (email == null || sub == null) {
-            throw new OAuth2AuthenticationException("필수 인증 정보(email, sub)가 누락되었습니다.");
-        }
-
         return userRepository.findByEmail(email)
                 .map(entity -> entity.update(name, picture, registrationId, sub))
                 .orElseGet(() -> {
-                    // [보고] 닉네임 중복 방지 및 길이 초과 방지를 위해 무작위 UUID 기반 닉네임 생성
-                    String safeNickname = "user_" + UUID.randomUUID().toString().substring(0, 8);
-                    
+                    // [보고] 닉네임 자동 생성 시 중복 방지 로직 추가
+                    String safeNickname = generateUniqueNickname();
+
                     return userRepository.save(User.builder()
                             .email(email)
                             .name(name)
                             .nickname(safeNickname)
                             .profileImageUrl(picture)
-                            // [수정] 신규 가입 유저의 기본 권한을 온보딩용 GUEST로 설정함
                             .role(Role.GUEST)
                             .provider(registrationId)
                             .providerId(sub)
                             .build());
                 });
+    }
+
+    private String generateUniqueNickname() {
+        String nickname;
+        do {
+            nickname = "user_" + UUID.randomUUID().toString().substring(0, 8);
+        } while (userRepository.existsByNickname(nickname)); // 중복이면 다시 생성
+        return nickname;
     }
 }

--- a/backend/src/main/java/com/devnear/web/service/notification/NotificationService.java
+++ b/backend/src/main/java/com/devnear/web/service/notification/NotificationService.java
@@ -17,10 +17,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import java.util.Objects;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -31,20 +31,27 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
 
+    /**
+     * [수정] User 엔티티 대신 userId(Long)를 직접 받도록 변경
+     */
     @Transactional(readOnly = true)
-    public NotificationInboxResponse getInbox(User user, Pageable pageable) {
-        long unread = notificationRepository.countUnreadByUserId(user.getId());
+    public NotificationInboxResponse getInbox(Long userId, Pageable pageable) {
+        long unread = notificationRepository.countUnreadByUserId(userId);
         Page<NotificationResponse> page = notificationRepository
-                .findByUser_IdOrderByCreatedAtDesc(user.getId(), pageable)
+                .findByUser_IdOrderByCreatedAtDesc(userId, pageable)
                 .map(NotificationResponse::fromEntity);
         return NotificationInboxResponse.of(unread, page);
     }
 
+    /**
+     * [수정] User 엔티티 대신 userId(Long)를 직접 받도록 변경
+     */
     @Transactional
-    public void markNotificationRead(User user, Long notificationId) {
+    public void markNotificationRead(Long userId, Long notificationId) {
         Notification notification = notificationRepository
-                .findByIdAndUser_Id(notificationId, user.getId())
+                .findByIdAndUser_Id(notificationId, userId)
                 .orElseThrow(() -> new ResourceNotFoundException("알림을 찾을 수 없습니다."));
+
         if (!notification.isRead()) {
             notification.markRead();
         }
@@ -59,8 +66,10 @@ public class NotificationService {
         Objects.requireNonNull(type, "알림 타입은 null일 수 없습니다.");
         Objects.requireNonNull(title, "알림 제목은 null일 수 없습니다.");
         Objects.requireNonNull(message, "알림 메시지는 null일 수 없습니다.");
+
         User targetUser = userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("수신자를 찾을 수 없습니다."));
+
         String content = title + "\n" + message;
         Notification saved = notificationRepository.save(Notification.builder()
                 .user(targetUser)
@@ -69,9 +78,11 @@ public class NotificationService {
                 .read(false)
                 .url(buildUrl(type, resourceId))
                 .build());
+
         Instant at = saved.getCreatedAt() != null
                 ? saved.getCreatedAt().atZone(ZoneId.systemDefault()).toInstant()
                 : Instant.now();
+
         NotificationPayload payload = NotificationPayload.of(
                 saved.getId(),
                 type,
@@ -81,6 +92,7 @@ public class NotificationService {
                 saved.getUrl(),
                 at
         );
+
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
@@ -94,11 +106,8 @@ public class NotificationService {
             return null;
         }
         return switch (type) {
-            // 문의하기는 알림 링크 대신 화면 내 "문의하기" 버튼에서 처리
             case CHAT_ROOM_CREATED -> null;
-            // 역제안 도착 알림만 링크 이동 허용
             case PROJECT_PROPOSAL_SENT -> "/freelancer/mypage";
-            // 수락/거절은 우측 X로 확인 처리
             case PROJECT_PROPOSAL_ACCEPTED, PROJECT_PROPOSAL_REJECTED -> null;
             case PROJECT_APPLICATION_SUBMITTED -> "/client/dashboard";
             case PROJECT_APPLICATION_ACCEPTED, PROJECT_APPLICATION_REJECTED -> null;

--- a/backend/src/main/java/com/devnear/web/service/user/UserService.java
+++ b/backend/src/main/java/com/devnear/web/service/user/UserService.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import org.springframework.cache.annotation.CacheEvict;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -38,7 +38,8 @@ public class UserService {
 
     @Transactional
     public Long register(UserRegisterRequest request) {
-        // [N+1 팁] 중복 체크 시에는 EntityGraph가 없는 전용 메서드나 existsByEmail을 쓰는 게 더 가볍습니다.
+        // [보안 팁] 혹시 모를 중복 가입 시도 방지를 위해 가입 시에도 캐시를 비워주는 것이 타당
+        // 하지만 가입 시엔 보통 캐시가 없으므로 생략 가능
         if (userRepository.findByEmail(request.getEmail()).isPresent()) {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
         }
@@ -60,9 +61,9 @@ public class UserService {
         return new TokenResponse(token, "Bearer");
     }
 
+    @CacheEvict(value = "users", key = "#email") // 👈 [추가] 권한 승격 시 캐시 삭제!
     @Transactional
     public TokenResponse onboarding(String email, OnboardingRequest request) {
-        // 여기서 이미 Freelancer/Client Profile을 JOIN으로 다 가져왔습니다!
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
 
@@ -128,6 +129,7 @@ public class UserService {
         return new UserInfoResponse(user);
     }
 
+    @CacheEvict(value = "users", key = "#email") // 👈 [추가] 프로필 이미지 변경 시에도 캐시 삭제
     @Transactional
     public void updateProfileImage(String email, String newImageUrl) {
         User user = userRepository.findByEmail(email)

--- a/backend/src/main/java/com/devnear/web/service/user/UserService.java
+++ b/backend/src/main/java/com/devnear/web/service/user/UserService.java
@@ -12,19 +12,17 @@ import com.devnear.web.domain.skill.SkillRepository;
 import com.devnear.web.domain.user.User;
 import com.devnear.web.domain.user.UserRepository;
 import com.devnear.web.dto.freelancer.FreelancerProfileRequest;
-import com.devnear.web.dto.user.OnboardingRequest;
-import com.devnear.web.dto.user.TokenResponse;
-import com.devnear.web.dto.user.UserInfoResponse;
-import com.devnear.web.dto.user.UserRegisterRequest;
-import com.devnear.web.dto.user.UserLoginRequest;
+import com.devnear.web.dto.user.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.dao.DataIntegrityViolationException; // 👈 예외 처리 필수 임포트
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.cache.annotation.CacheEvict;
+
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -37,16 +35,28 @@ public class UserService {
     private final FreelancerProfileRepository freelancerProfileRepository;
     private final SkillRepository skillRepository;
 
+    /**
+     * 회원 가입
+     * [수정] 동시성 이슈 대응을 위해 try-catch 블록 추가
+     */
     @Transactional
     public Long register(UserRegisterRequest request) {
-        // [보안 팁] 혹시 모를 중복 가입 시도 방지를 위해 가입 시에도 캐시를 비워주는 것이 타당
-        // 하지만 가입 시엔 보통 캐시가 없으므로 생략 가능
+        // 1차 체크 (대부분 여기서 걸러짐)
         if (userRepository.findByEmail(request.getEmail()).isPresent()) {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
         }
-        String encodedPassword = passwordEncoder.encode(request.getPassword());
-        User user = request.toEntity(encodedPassword);
-        return userRepository.save(user).getId();
+
+        try {
+            String encodedPassword = passwordEncoder.encode(request.getPassword());
+            User user = request.toEntity(encodedPassword);
+
+            // 2차 방어: DB Unique 제약 조건 위반 시 Catch
+            // saveAndFlush를 사용하여 메서드 내부에서 즉시 예외를 발생시키고 잡을 수 있게 함
+            return userRepository.save(user).getId();
+        } catch (DataIntegrityViolationException e) {
+            // 동시 가입 시도가 발생하여 1차 체크를 통과했더라도 DB 레이어에서 최종 차단
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        }
     }
 
     @Transactional
@@ -62,11 +72,12 @@ public class UserService {
         return new TokenResponse(token, "Bearer");
     }
 
-    @CacheEvict(value = "users", key = "#email") // 👈 [추가] 권한 승격 시 캐시 삭제!
+    @CacheEvict(value = "users", key = "#email")
     @Transactional
     public TokenResponse onboarding(String email, OnboardingRequest request) {
         User user = userRepository.findByEmailForUpdate(email)
                 .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+
         if (user.getStatus() == UserStatus.WITHDRAWN) {
             throw new IllegalArgumentException("탈퇴 처리된 계정입니다.");
         }
@@ -78,9 +89,8 @@ public class UserService {
 
         user.onboard(request.getNickname(), request.getRole());
 
-        // 2. 클라이언트 프로필 처리
+        // 클라이언트 프로필 처리
         if (request.getRole() == Role.CLIENT || request.getRole() == Role.BOTH) {
-            // [리팩터링] 레포지토리를 또 조회하지 않고, user 객체에 이미 로드된 프로필을 사용합니다.
             if (user.getClientProfile() != null) {
                 user.getClientProfile().update(request.getClientProfile());
             } else {
@@ -88,9 +98,8 @@ public class UserService {
             }
         }
 
-        // 3. 프리랜서 프로필 처리
+        // 프리랜서 프로필 처리
         if (request.getRole() == Role.FREELANCER || request.getRole() == Role.BOTH) {
-            // [리팩터링] 마찬가지로 user.getFreelancerProfile()로 즉시 확인하여 쿼리를 줄입니다.
             if (user.getFreelancerProfile() != null) {
                 throw new IllegalStateException("이미 프리랜서 프로필이 존재합니다.");
             }
@@ -127,13 +136,12 @@ public class UserService {
     }
 
     public UserInfoResponse getUserInfo(String email) {
-        // 정보 조회 시 Profile 정보가 포함된다면 EntityGraph의 효과를 톡톡히 봅니다.
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
         return new UserInfoResponse(user);
     }
 
-    @CacheEvict(value = "users", key = "#email") // 👈 [추가] 프로필 이미지 변경 시에도 캐시 삭제
+    @CacheEvict(value = "users", key = "#email")
     @Transactional
     public void updateProfileImage(String email, String newImageUrl) {
         User user = userRepository.findByEmailForUpdate(email)

--- a/backend/src/main/java/com/devnear/web/service/user/UserService.java
+++ b/backend/src/main/java/com/devnear/web/service/user/UserService.java
@@ -24,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -39,6 +38,7 @@ public class UserService {
 
     @Transactional
     public Long register(UserRegisterRequest request) {
+        // [N+1 팁] 중복 체크 시에는 EntityGraph가 없는 전용 메서드나 existsByEmail을 쓰는 게 더 가볍습니다.
         if (userRepository.findByEmail(request.getEmail()).isPresent()) {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
         }
@@ -60,50 +60,37 @@ public class UserService {
         return new TokenResponse(token, "Bearer");
     }
 
-    /**
-     * [최종 통합] 온보딩 로직: 닉네임/역할 업데이트 및 각 프로필 동시 저장
-     */
     @Transactional
     public TokenResponse onboarding(String email, OnboardingRequest request) {
+        // 여기서 이미 Freelancer/Client Profile을 JOIN으로 다 가져왔습니다!
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
 
-        // [보고] 팀원 에러 픽스: 소셜 로그인 시 이미 부여된 닉네임(user.getNickname())과 입력한 닉네임이 다를 때만 중복 검사
         if (!Objects.equals(user.getNickname(), request.getNickname()) &&
                 userRepository.existsByNickname(request.getNickname())) {
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }
 
-        // 1. 유저 기본 정보 업데이트
         user.onboard(request.getNickname(), request.getRole());
 
-        // [보고] 500 에러 방지를 위해 필수 프로필 정보 누락 검증
-        if ((request.getRole() == Role.CLIENT || request.getRole() == Role.BOTH) && request.getClientProfile() == null) {
-            throw new IllegalArgumentException("클라이언트 프로필 정보가 누락되었습니다.");
-        }
-        if ((request.getRole() == Role.FREELANCER || request.getRole() == Role.BOTH) && request.getFreelancerProfile() == null) {
-            throw new IllegalArgumentException("프리랜서 프로필 정보가 누락되었습니다.");
-        }
-
-        // 2. 클라이언트 프로필 저장 (CLIENT 또는 BOTH)
+        // 2. 클라이언트 프로필 처리
         if (request.getRole() == Role.CLIENT || request.getRole() == Role.BOTH) {
-            // [보고] 리뷰 반영: 멱등성 보장 - 기존 프로필이 있으면 업데이트, 없으면 생성
-            clientProfileRepository.findByUser(user)
-                    .ifPresentOrElse(
-                            existingProfile -> existingProfile.update(request.getClientProfile()), // 이미 있으면 Update
-                            () -> clientProfileRepository.save(request.getClientProfile().toEntity(user)) // 없으면 Create
-                    );
+            // [리팩터링] 레포지토리를 또 조회하지 않고, user 객체에 이미 로드된 프로필을 사용합니다.
+            if (user.getClientProfile() != null) {
+                user.getClientProfile().update(request.getClientProfile());
+            } else {
+                clientProfileRepository.save(request.getClientProfile().toEntity(user));
+            }
         }
 
-        // 3. 프리랜서 프로필 저장 (FREELANCER 또는 BOTH)
+        // 3. 프리랜서 프로필 처리
         if (request.getRole() == Role.FREELANCER || request.getRole() == Role.BOTH) {
-            FreelancerProfileRequest fReq = request.getFreelancerProfile();
-
-            // [보고] 리뷰 반영: 멱등성 보장 - 기존 프리랜서 프로필이 이미 있으면 에러 처리(혹은 Update)
-            if (freelancerProfileRepository.findByUser_Id(user.getId()).isPresent()) {
+            // [리팩터링] 마찬가지로 user.getFreelancerProfile()로 즉시 확인하여 쿼리를 줄입니다.
+            if (user.getFreelancerProfile() != null) {
                 throw new IllegalStateException("이미 프리랜서 프로필이 존재합니다.");
             }
 
+            FreelancerProfileRequest fReq = request.getFreelancerProfile();
             FreelancerProfile profile = FreelancerProfile.builder()
                     .user(user)
                     .introduction(fReq.getIntroduction())
@@ -115,7 +102,6 @@ public class UserService {
                     .isActive(true)
                     .build();
 
-            // 스킬 ID 리스트를 실제 FreelancerSkill 엔티티 리스트로 변환
             List<FreelancerSkill> skills = fReq.getSkillIds().stream()
                     .map(skillId -> {
                         Skill skill = skillRepository.findById(skillId)
@@ -125,32 +111,27 @@ public class UserService {
                                 .skill(skill)
                                 .build();
                     })
-                    .collect(Collectors.toList());
+                    .toList();
 
             profile.updateSkills(skills);
             freelancerProfileRepository.save(profile);
         }
 
-        // [보고] 모든 DB 저장이 성공적으로 끝나면 권한이 승격된 토큰을 새로 발급
         String newToken = jwtTokenProvider.createToken(user.getId(), user.getEmail(), user.getRole().name());
         return new TokenResponse(newToken, "Bearer");
     }
 
     public UserInfoResponse getUserInfo(String email) {
+        // 정보 조회 시 Profile 정보가 포함된다면 EntityGraph의 효과를 톡톡히 봅니다.
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
         return new UserInfoResponse(user);
     }
 
-    /**
-     * [Cloudinary] 프로필 이미지 URL을 DB에 반영합니다.
-     * ImageController에서 Cloudinary 업로드 완료 후 호출됩니다.
-     */
     @Transactional
     public void updateProfileImage(String email, String newImageUrl) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
         user.updateProfileImageUrl(newImageUrl);
-        // @Transactional + Dirty Checking으로 별도 save() 불필요
     }
 }


### PR DESCRIPTION
## 🔎 What

1️⃣ Redis 세션 연동 및 Security DTO 전환
문제 상황: JPA User 엔티티를 레디스에 직접 넣으려다 직렬화 에러와 성능 저하 발생
해결책: 가벼운 신분증인 SecurityUser (DTO)를 만들어 세션에 저장하도록 분리
->Argument Resolver를 도입해서, 컨트롤러에서는 예전처럼 @LoginUser User user로 엔티티를 바로 사용할 수 있게 인프라를 구축
2️⃣ UserRepository @EntityGraph 도입
문제 상황: 유저가 로그인할 때 이메일로 유저를 찾은 뒤, 프로필 정보를 가져오느라 추가 쿼리가 발생하는 N+1 쿼리 조짐이 보임
해결책: findByEmail 메서드에 @EntityGraph를 붙여서 User를 찾을 때 ClientProfile과 FreelancerProfile을 한 번의 LEFT OUTER JOIN으로 싹 긁어오게 개선
->로그에서 확인한 것처럼 tjddl5@naver.com을 조회할 때 단 한 줄의 타당한 쿼리만 나감

## 🔗 Issue

- Closes: #113 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-level caching with Redis enabled to speed up authentication and user lookups.

* **Bug Fixes**
  * System-generated user nicknames now guaranteed unique.
  * Improved onboarding/profile updates to avoid inconsistent duplicate entries.

* **Refactor**
  * Reduced redundant profile loading to improve API performance.

* **Chores**
  * Added SQL query logging (development-only) for performance diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->