### PR TITLE
[feat]164 Enhancing 1:1 Chat UI/UX and Upgrading Read Receipt Functionality

### DIFF
--- a/backend/src/main/java/com/devnear/web/controller/chat/ChatController.java
+++ b/backend/src/main/java/com/devnear/web/controller/chat/ChatController.java
@@ -1,7 +1,9 @@
 package com.devnear.web.controller.chat;
 
+import com.devnear.global.auth.LoginUser;
 import com.devnear.web.domain.user.User;
 import com.devnear.web.dto.chat.ChatMessageResponse;
+import com.devnear.web.dto.chat.ChatReadReceiptResponse;
 import com.devnear.web.dto.chat.ChatRoomCreateRequest;
 import com.devnear.web.dto.chat.ChatRoomListResponse;
 import com.devnear.web.dto.chat.ChatRoomResponse;
@@ -12,9 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import com.devnear.global.auth.LoginUser;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,8 +26,8 @@ import java.util.List;
 public class ChatController {
 
     private final ChatService chatService;
+    private final SimpMessagingTemplate messagingTemplate;
 
-    // 채팅방 생성 API
     @Operation(summary = "채팅방 생성", description = "프로젝트 기준 1대1 채팅방을 생성하거나 기존 방을 반환합니다.")
     @PostMapping("/rooms")
     public ResponseEntity<ChatRoomResponse> createRoom(
@@ -38,7 +38,6 @@ public class ChatController {
                 .body(chatService.createRoom(user, request));
     }
 
-    // 내 채팅방 목록 조회 API
     @Operation(summary = "내 채팅방 목록 조회")
     @GetMapping("/rooms")
     public ResponseEntity<List<ChatRoomListResponse>> getMyRooms(
@@ -47,7 +46,6 @@ public class ChatController {
         return ResponseEntity.ok(chatService.getMyRooms(user));
     }
 
-    // 특정 채팅방 메시지 조회 API
     @Operation(summary = "채팅 메시지 조회")
     @GetMapping("/rooms/{roomId}/messages")
     public ResponseEntity<List<ChatMessageResponse>> getMessages(
@@ -58,18 +56,25 @@ public class ChatController {
     ) {
         if (page < 0) page = 0;
         if (size < 1) size = 1;
-        if (size > 100) size = 100; // Cap maximum page size
+        if (size > 100) size = 100;
         return ResponseEntity.ok(chatService.getMessages(user, roomId, page, size));
     }
 
-    // 특정 채팅방 읽음 처리 API
     @Operation(summary = "읽음 처리")
     @PatchMapping("/rooms/{roomId}/read")
     public ResponseEntity<Void> markAsRead(
             @LoginUser User user,
             @PathVariable Long roomId
     ) {
-        chatService.markAsRead(user, roomId);
+        int updatedCount = chatService.markAsRead(user, roomId);
+
+        if (updatedCount > 0) {
+            messagingTemplate.convertAndSend(
+                    "/sub/chat/rooms/" + roomId + "/read",
+                    ChatReadReceiptResponse.of(roomId, user.getId())
+            );
+        }
+
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/devnear/web/domain/chat/ChatMessageRepository.java
+++ b/backend/src/main/java/com/devnear/web/domain/chat/ChatMessageRepository.java
@@ -8,41 +8,30 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
-    // 특정 채팅방의 전체 메시지를 오래된 순서부터 조회 (불필요한 대용량 조회용, 가능하면 페이지 사용)
     @EntityGraph(attributePaths = {"sender"})
     List<ChatMessage> findAllByChatRoomOrderByCreatedAtAsc(ChatRoom chatRoom);
 
-    // Pageable variant for bounded queries
     @EntityGraph(attributePaths = {"sender"})
     Page<ChatMessage> findByChatRoomOrderByCreatedAtAsc(ChatRoom chatRoom, Pageable pageable);
 
-    // 마지막 메시지 1개 조회
-    // 채팅방 목록에서 미리보기용으로 사용
     Optional<ChatMessage> findTopByChatRoomOrderByCreatedAtDesc(ChatRoom chatRoom);
 
-    // 내가 보낸 메시지를 제외하고, 아직 안 읽은 메시지 개수 조회
     long countByChatRoomAndSenderNotAndIsReadFalse(ChatRoom chatRoom, User user);
 
-    // 내가 받은 메시지 중 아직 안 읽은 메시지들 조회
     List<ChatMessage> findByChatRoomAndSenderNotAndIsReadFalse(ChatRoom chatRoom, User user);
 
-    // Bulk: 가장 최근 메시지들을 여러 채팅방에 대해 한 번에 조회 (네이티브 쿼리)
     @Query(value = "SELECT m.* FROM chat_messages m " +
             "JOIN (SELECT chat_room_id, MAX(created_at) AS last_at FROM chat_messages WHERE chat_room_id IN :roomIds GROUP BY chat_room_id) lm " +
             "ON m.chat_room_id = lm.chat_room_id AND m.created_at = lm.last_at",
             nativeQuery = true)
     List<ChatMessage> findLastMessagesForChatRooms(@Param("roomIds") List<Long> roomIds);
 
-    // Bulk: 채팅방별 읽지 않은 메시지 개수 (sender != :meId)
     @Query(value = "SELECT chat_room_id AS room_id, COUNT(*) AS cnt FROM chat_messages " +
             "WHERE chat_room_id IN :roomIds AND is_read = false AND sender_id <> :meId " +
             "GROUP BY chat_room_id",
@@ -53,9 +42,17 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     @Query("DELETE FROM ChatMessage m WHERE m.chatRoom.project.id = :projectId")
     void deleteByProjectId(@Param("projectId") Long projectId);
 
-
-
-    // 👇 이거 추가 (내림차순)
     @EntityGraph(attributePaths = {"sender"})
     Page<ChatMessage> findByChatRoomOrderByCreatedAtDesc(ChatRoom chatRoom, Pageable pageable);
+
+    // 읽음 처리 bulk update
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE ChatMessage m
+        SET m.isRead = true
+        WHERE m.chatRoom = :room
+          AND m.sender <> :user
+          AND m.isRead = false
+    """)
+    int markAllAsRead(@Param("room") ChatRoom room, @Param("user") User user);
 }

--- a/backend/src/main/java/com/devnear/web/domain/chat/ChatRoomRepository.java
+++ b/backend/src/main/java/com/devnear/web/domain/chat/ChatRoomRepository.java
@@ -13,16 +13,24 @@ import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    // 특정 프로젝트 안에서 user1, user2 조합의 채팅방이 있는지 찾기
-    // EntityGraph를 사용해서 user, project를 함께 가져오면 N+1 문제를 줄일 수 있음
+    // 특정 프로젝트 안에서 user1, user2 조합의 채팅방 조회
     @EntityGraph(attributePaths = {"user1", "user2", "project", "project.clientProfile", "project.freelancerProfile"})
     Optional<ChatRoom> findByProjectAndUser1AndUser2(Project project, User user1, User user2);
 
     // 내가 참여한 모든 채팅방 조회
-    // user1 또는 user2 중 하나라도 나이면 조회
-    // updatedAt 기준 최신순 정렬
     @EntityGraph(attributePaths = {"user1", "user2", "project"})
     List<ChatRoom> findAllByUser1OrUser2OrderByUpdatedAtDesc(User user1, User user2);
+
+    // 같은 두 유저 사이의 모든 채팅방 조회 (프로젝트 무관)
+    @EntityGraph(attributePaths = {"user1", "user2", "project"})
+    @Query("""
+        SELECT cr
+        FROM ChatRoom cr
+        WHERE (cr.user1 = :user1 AND cr.user2 = :user2)
+           OR (cr.user1 = :user2 AND cr.user2 = :user1)
+        ORDER BY cr.updatedAt DESC
+    """)
+    List<ChatRoom> findAllByUsers(@Param("user1") User user1, @Param("user2") User user2);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM ChatRoom c WHERE c.project.id = :projectId")

--- a/backend/src/main/java/com/devnear/web/dto/chat/ChatReadReceiptResponse.java
+++ b/backend/src/main/java/com/devnear/web/dto/chat/ChatReadReceiptResponse.java
@@ -1,0 +1,21 @@
+package com.devnear.web.dto.chat;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatReadReceiptResponse {
+
+    private Long roomId;
+    private Long readerId;
+    private boolean read;
+
+    public static ChatReadReceiptResponse of(Long roomId, Long readerId) {
+        return ChatReadReceiptResponse.builder()
+                .roomId(roomId)
+                .readerId(readerId)
+                .read(true)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/devnear/web/dto/chat/ChatRoomListResponse.java
+++ b/backend/src/main/java/com/devnear/web/dto/chat/ChatRoomListResponse.java
@@ -22,9 +22,24 @@ public class ChatRoomListResponse {
     private LocalDateTime lastMessageAt;
     private long unreadCount;
 
-    // 채팅방 목록 화면에서 보여줄 정보 생성
+    // 추가
+    private boolean lastMessageMine;
+    private boolean lastMessageRead;
+    private boolean lastMessageSystem;
+
     public static ChatRoomListResponse of(ChatRoom room, User me, ChatMessage lastMessage, long unreadCount) {
         User opponent = room.getOpponent(me);
+
+        boolean lastMessageMine = false;
+        boolean lastMessageRead = false;
+        boolean lastMessageSystem = false;
+
+        if (lastMessage != null) {
+            lastMessageMine = lastMessage.getSender() != null
+                    && lastMessage.getSender().getId().equals(me.getId());
+            lastMessageRead = lastMessage.isRead();
+            lastMessageSystem = lastMessage.isSystemMessage();
+        }
 
         return ChatRoomListResponse.builder()
                 .roomId(room.getId())
@@ -36,6 +51,9 @@ public class ChatRoomListResponse {
                 .lastMessage(lastMessage != null ? lastMessage.getContent() : null)
                 .lastMessageAt(lastMessage != null ? lastMessage.getCreatedAt() : null)
                 .unreadCount(unreadCount)
+                .lastMessageMine(lastMessageMine)
+                .lastMessageRead(lastMessageRead)
+                .lastMessageSystem(lastMessageSystem)
                 .build();
     }
 }

--- a/backend/src/main/java/com/devnear/web/service/chat/ChatService.java
+++ b/backend/src/main/java/com/devnear/web/service/chat/ChatService.java
@@ -32,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -162,6 +163,12 @@ public class ChatService {
     }
 
     private ChatRoomResponse createOrGetRoom(User me, User target, Project project) {
+        // 같은 상대와 이미 대화한 방이 있으면 최신 방 재사용
+        List<ChatRoom> existingRooms = chatRoomRepository.findAllByUsers(me, target);
+        if (!existingRooms.isEmpty()) {
+            return ChatRoomResponse.from(existingRooms.get(0), me);
+        }
+
         AtomicBoolean createdNew = new AtomicBoolean(false);
         ChatRoom room = resolveOrCreateChatRoom(project, me, target, createdNew);
 
@@ -242,7 +249,15 @@ public class ChatService {
             return List.of();
         }
 
-        List<Long> roomIds = rooms.stream()
+        // 같은 상대와의 여러 방이 있더라도 최신 방 하나만 목록에 노출
+        Map<Long, ChatRoom> latestRoomByOpponentId = new LinkedHashMap<>();
+        for (ChatRoom room : rooms) {
+            Long opponentId = room.getOpponent(me).getId();
+            latestRoomByOpponentId.putIfAbsent(opponentId, room);
+        }
+
+        List<ChatRoom> deduplicatedRooms = latestRoomByOpponentId.values().stream().toList();
+        List<Long> roomIds = deduplicatedRooms.stream()
                 .map(ChatRoom::getId)
                 .toList();
 
@@ -264,7 +279,7 @@ public class ChatService {
             unreadCountMap.put(roomIdNum.longValue(), countNum.longValue());
         }
 
-        return rooms.stream()
+        return deduplicatedRooms.stream()
                 .map(room -> {
                     ChatMessage lastMessage = lastMessageMap.get(room.getId());
                     long unreadCount = unreadCountMap.getOrDefault(room.getId(), 0L);
@@ -297,13 +312,9 @@ public class ChatService {
     }
 
     @Transactional
-    public void markAsRead(User me, Long roomId) {
+    public int markAsRead(User me, Long roomId) {
         ChatRoom room = getValidatedRoom(me, roomId);
-
-        List<ChatMessage> unreadMessages =
-                chatMessageRepository.findByChatRoomAndSenderNotAndIsReadFalse(room, me);
-
-        unreadMessages.forEach(ChatMessage::markAsRead);
+        return chatMessageRepository.markAllAsRead(room, me);
     }
 
     @Transactional

--- a/frontend/app/lib/chatSocket.ts
+++ b/frontend/app/lib/chatSocket.ts
@@ -1,93 +1,65 @@
 import { Client, IMessage, StompSubscription } from "@stomp/stompjs";
 import SockJS from "sockjs-client";
-import { resolveSockJsUrl } from "./wsUrl";
 
 let client: Client | null = null;
-let connectingPromise: Promise<Client> | null = null;
 
-function getAccessToken(): string | null {
-    if (typeof window === "undefined") return null;
-    return localStorage.getItem("accessToken");
-}
-
-function resolveChatSocketUrl(): string {
-    return process.env.NEXT_PUBLIC_WS_URL?.trim() || resolveSockJsUrl();
-}
-
-export function connectChatSocket(onConnect?: () => void) {
-    if (client?.active) return client;
+export const connectChatSocket = () => {
+    if (client && client.connected) return;
 
     client = new Client({
-        webSocketFactory: () => new SockJS(resolveChatSocketUrl()),
+        webSocketFactory: () => new SockJS("http://localhost:8080/ws"),
         reconnectDelay: 5000,
-        debug: () => {},
-        beforeConnect: () => {
-            const token = getAccessToken();
-            client!.connectHeaders = token
-                ? { Authorization: `Bearer ${token}` }
-                : {};
-        },
-        onConnect: () => {
-            onConnect?.();
-        },
-        onStompError: (frame) => {
-            console.error("STOMP 에러", frame);
-        },
-        onWebSocketError: (event) => {
-            console.error("WebSocket 에러", event);
-        },
     });
+
+    client.onConnect = () => {
+        console.log("WebSocket 연결 성공");
+    };
+
+    client.onStompError = (frame) => {
+        console.error("STOMP error", frame);
+    };
 
     client.activate();
-    return client;
-}
+};
 
-export async function ensureChatSocketConnected(): Promise<Client> {
-    if (client?.connected) return client;
-    if (connectingPromise) return connectingPromise;
-
-    connectingPromise = new Promise((resolve, reject) => {
-        const socketClient = connectChatSocket();
-
-        const timeout = setTimeout(() => {
-            connectingPromise = null;
-            reject(new Error("채팅 소켓 연결 시간 초과"));
-        }, 5000);
-
-        const originalOnConnect = socketClient.onConnect;
-        const originalOnWebSocketError = socketClient.onWebSocketError;
-
-        socketClient.onConnect = (frame) => {
-            clearTimeout(timeout);
-            connectingPromise = null;
-            originalOnConnect?.(frame);
-            resolve(socketClient);
-        };
-
-        socketClient.onWebSocketError = (event) => {
-            clearTimeout(timeout);
-            connectingPromise = null;
-            originalOnWebSocketError?.(event);
-            reject(new Error("채팅 소켓 연결 실패"));
-        };
-    });
-
-    return connectingPromise;
-}
-
-export function disconnectChatSocket() {
-    if (client) {
+export const disconnectChatSocket = () => {
+    if (client && client.connected) {
         client.deactivate();
         client = null;
     }
-    connectingPromise = null;
-}
+};
 
-export async function subscribeChatRoom(
+export const ensureChatSocketConnected = async () => {
+    if (!client) {
+        connectChatSocket();
+    }
+
+    return new Promise<void>((resolve) => {
+        const check = () => {
+            if (client && client.connected) {
+                resolve();
+            } else {
+                setTimeout(check, 100);
+            }
+        };
+        check();
+    });
+};
+
+export const subscribeChatRoom = (
+    roomId: number,
+    callback: (message: IMessage) => void
+): StompSubscription => {
+    if (!client || !client.connected) {
+        throw new Error("WebSocket not connected");
+    }
+
+    return client.subscribe(`/sub/chat/rooms/${roomId}`, callback);
+};
+export async function subscribeChatReadReceipt(
     roomId: number,
     callback: (message: IMessage) => void
 ): Promise<StompSubscription> {
     const socketClient = await ensureChatSocketConnected();
-    return socketClient.subscribe(`/sub/chat/rooms/${roomId}`, callback);
-
+    return socketClient.subscribe(`/sub/chat/rooms/${roomId}/read`, callback);
 }

--- a/frontend/components/chat/ChatInput.tsx
+++ b/frontend/components/chat/ChatInput.tsx
@@ -38,7 +38,7 @@ export default function ChatInput({
                     onCompositionStart={() => setIsComposing(true)}
                     onCompositionEnd={() => setIsComposing(false)}
                     onKeyDown={(e) => {
-                        if (e.key === "Enter" && !disabled && !isComposing) {
+                        if (e.key === "Enter" && !e.shiftKey && !disabled && !isComposing) {
                             e.preventDefault();
                             onSend();
                         }

--- a/frontend/components/chat/ChatMessageBubble.tsx
+++ b/frontend/components/chat/ChatMessageBubble.tsx
@@ -2,24 +2,38 @@ interface ChatMessageBubbleProps {
     message: string;
     time: string;
     isMine: boolean;
+    isRead?: boolean;
     senderNickname?: string;
+    systemMessage?: boolean;
 }
 
 export default function ChatMessageBubble({
                                               message,
                                               time,
                                               isMine,
+                                              isRead = false,
                                               senderNickname,
+                                              systemMessage = false,
                                           }: ChatMessageBubbleProps) {
+    if (systemMessage) {
+        return (
+            <div className="flex justify-center">
+                <div className="max-w-[85%] rounded-full bg-gray-200 px-3 py-1.5 text-center text-[11px] text-gray-600">
+                    {message}
+                </div>
+            </div>
+        );
+    }
+
     return (
         <div className={`flex ${isMine ? "justify-end" : "justify-start"}`}>
             <div
-                className={`flex max-w-[75%] flex-col ${
+                className={`flex max-w-[78%] flex-col ${
                     isMine ? "items-end" : "items-start"
                 }`}
             >
                 {!isMine && senderNickname && (
-                    <span className="mb-1 px-1 text-[11px] text-gray-400">
+                    <span className="mb-1 px-1 text-[11px] font-medium text-gray-500">
                         {senderNickname}
                     </span>
                 )}
@@ -34,7 +48,16 @@ export default function ChatMessageBubble({
                     {message}
                 </div>
 
-                <span className="mt-1 px-1 text-[11px] text-gray-400">{time}</span>
+                {(time || isMine) && (
+                    <div className="mt-1 flex items-center gap-1 px-1 text-[11px] text-gray-400">
+                        {isMine && (
+                            <span className={isRead ? "text-violet-600" : "text-gray-400"}>
+                                {isRead ? "읽음" : "전송됨"}
+                            </span>
+                        )}
+                        {time && <span>{time}</span>}
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/frontend/components/chat/ChatWidget.tsx
+++ b/frontend/components/chat/ChatWidget.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import type { StompSubscription } from "@stomp/stompjs";
+import type { StompSubscription, IMessage } from "@stomp/stompjs";
 import ChatWindow from "./ChatWindow";
 import {
     getChatMessages,
@@ -13,21 +13,34 @@ import {
     connectChatSocket,
     disconnectChatSocket,
     subscribeChatRoom,
+    subscribeChatReadReceipt,
     ensureChatSocketConnected,
 } from "../../app/lib/chatSocket";
 import { getCurrentUserId } from "../../app/lib/auth";
 import { useChatStore } from "../../app/store/chatStore";
-import type { ChatMessageResponse, ChatRoomListResponse } from "../../types/chat";
+import type {
+    ChatMessageResponse,
+    ChatReadReceiptResponse,
+    ChatRoomListResponse,
+} from "../../types/chat";
+
+type ChatView = "list" | "room";
 
 function sortRoomsByLatest(roomList: ChatRoomListResponse[]) {
     return [...roomList].sort((a, b) => {
-        const aTime = a.lastMessageTime ? new Date(a.lastMessageTime).getTime() : 0;
-        const bTime = b.lastMessageTime ? new Date(b.lastMessageTime).getTime() : 0;
+        const aTime = a.lastMessageAt ? new Date(a.lastMessageAt).getTime() : 0;
+        const bTime = b.lastMessageAt ? new Date(b.lastMessageAt).getTime() : 0;
+
+        if (bTime === aTime) {
+            return b.roomId - a.roomId;
+        }
+
         return bTime - aTime;
     });
 }
 
 export default function ChatWidget() {
+    const [view, setView] = useState<ChatView>("list");
     const [input, setInput] = useState("");
     const [rooms, setRooms] = useState<ChatRoomListResponse[]>([]);
     const [messages, setMessages] = useState<ChatMessageResponse[]>([]);
@@ -42,20 +55,23 @@ export default function ChatWidget() {
     const selectedRoomIdRef = useRef<number | null>(null);
     const currentUserIdRef = useRef<number | null>(null);
     const latestMessageReqId = useRef(0);
-    const subscriptionRef = useRef<StompSubscription | (() => void) | null>(null);
 
-    const cleanupSubscription = () => {
-        const current = subscriptionRef.current;
+    const messageSubscriptionRef = useRef<StompSubscription | null>(null);
+    const readSubscriptionRef = useRef<StompSubscription | null>(null);
 
+    const cleanupSubscription = (
+        ref: React.MutableRefObject<StompSubscription | null>
+    ) => {
+        const current = ref.current;
         if (!current) return;
 
-        if (typeof current === "function") {
-            current();
-        } else if (typeof current.unsubscribe === "function") {
+        try {
             current.unsubscribe();
+        } catch (error) {
+            console.error("구독 해제 실패", error);
         }
 
-        subscriptionRef.current = null;
+        ref.current = null;
     };
 
     useEffect(() => {
@@ -68,26 +84,38 @@ export default function ChatWidget() {
         selectedRoomIdRef.current = selectedRoomId;
     }, [selectedRoomId]);
 
+    useEffect(() => {
+        if (!isOpen) return;
+
+        if (selectedRoomId) {
+            setView("room");
+        } else {
+            setView("list");
+        }
+    }, [isOpen, selectedRoomId]);
+
     const fetchRooms = async () => {
         try {
             setLoadingRooms(true);
 
             const roomData = await getChatRooms();
-            const sortedRooms = sortRoomsByLatest(roomData);
+
+            const filtered = roomData.filter(
+                (room) => room.lastMessage !== null || room.unreadCount > 0
+            );
+
+            const sortedRooms = sortRoomsByLatest(filtered);
             setRooms(sortedRooms);
 
             const currentSelectedRoomId = selectedRoomIdRef.current;
-
-            const nextSelectedRoomId =
+            const existsSelected =
                 currentSelectedRoomId !== null &&
-                sortedRooms.some((room) => room.roomId === currentSelectedRoomId)
-                    ? currentSelectedRoomId
-                    : sortedRooms[0]?.roomId ?? null;
+                sortedRooms.some((room) => room.roomId === currentSelectedRoomId);
 
-            setRoom(nextSelectedRoomId);
-
-            if (nextSelectedRoomId === null) {
+            if (!existsSelected && currentSelectedRoomId !== null) {
+                setRoom(null);
                 setMessages([]);
+                setView("list");
             }
         } catch (error) {
             console.error("채팅방 조회 실패", error);
@@ -127,9 +155,9 @@ export default function ChatWidget() {
     }, [isOpen]);
 
     useEffect(() => {
-        if (!isOpen || !selectedRoomId) return;
+        if (!isOpen || !selectedRoomId || view !== "room") return;
         fetchMessages(selectedRoomId);
-    }, [isOpen, selectedRoomId]);
+    }, [isOpen, selectedRoomId, view]);
 
     useEffect(() => {
         if (!isOpen) return;
@@ -137,7 +165,8 @@ export default function ChatWidget() {
         connectChatSocket();
 
         return () => {
-            cleanupSubscription();
+            cleanupSubscription(messageSubscriptionRef);
+            cleanupSubscription(readSubscriptionRef);
             disconnectChatSocket();
         };
     }, [isOpen]);
@@ -153,50 +182,101 @@ export default function ChatWidget() {
 
                 if (cancelled) return;
 
-                cleanupSubscription();
+                cleanupSubscription(messageSubscriptionRef);
+                cleanupSubscription(readSubscriptionRef);
 
-                const sub = subscribeChatRoom(selectedRoomId, async (frame) => {
-                    try {
-                        const newMessage: ChatMessageResponse = JSON.parse(frame.body);
-                        const isCurrentRoom = selectedRoomIdRef.current === newMessage.roomId;
-                        const isMyMessage =
-                            currentUserIdRef.current !== null &&
-                            newMessage.senderId === currentUserIdRef.current;
+                const messageSub = await subscribeChatRoom(
+                    selectedRoomId,
+                    async (frame: IMessage) => {
+                        try {
+                            const newMessage: ChatMessageResponse = JSON.parse(frame.body);
+                            const isCurrentRoom = selectedRoomIdRef.current === newMessage.roomId;
+                            const isMyMessage =
+                                currentUserIdRef.current !== null &&
+                                newMessage.senderId === currentUserIdRef.current;
 
-                        if (isCurrentRoom) {
-                            setMessages((prev) => {
-                                const exists = prev.some(
-                                    (msg) => msg.messageId === newMessage.messageId
-                                );
-                                if (exists) return prev;
-                                return [...prev, newMessage];
-                            });
+                            if (isCurrentRoom) {
+                                setMessages((prev) => {
+                                    const exists = prev.some(
+                                        (msg) => msg.messageId === newMessage.messageId
+                                    );
+                                    if (exists) return prev;
+                                    return [...prev, newMessage];
+                                });
 
-                            if (!isMyMessage) {
-                                await markChatAsRead(newMessage.roomId);
+                                if (!isMyMessage) {
+                                    await markChatAsRead(newMessage.roomId);
+                                }
                             }
-                        }
 
-                        setRooms((prev) => {
-                            const updated = prev.map((room) => {
-                                if (room.roomId !== newMessage.roomId) return room;
+                            setRooms((prev) => {
+                                const existing = prev.find(
+                                    (room) => room.roomId === newMessage.roomId
+                                );
 
-                                return {
-                                    ...room,
-                                    lastMessage: newMessage.content,
-                                    lastMessageTime: newMessage.createdAt,
-                                    unreadCount: isCurrentRoom ? 0 : room.unreadCount + 1,
-                                };
+                                if (!existing) {
+                                    return prev;
+                                }
+
+                                const updated = prev.map((room) => {
+                                    if (room.roomId !== newMessage.roomId) return room;
+
+                                    return {
+                                        ...room,
+                                        lastMessage: newMessage.content,
+                                        lastMessageAt: newMessage.createdAt,
+                                        lastMessageMine: isMyMessage,
+                                        lastMessageRead: newMessage.read,
+                                        lastMessageSystem: newMessage.systemMessage,
+                                        unreadCount:
+                                            isCurrentRoom || isMyMessage
+                                                ? 0
+                                                : room.unreadCount + 1,
+                                    };
+                                });
+
+                                return sortRoomsByLatest(updated);
                             });
-
-                            return sortRoomsByLatest(updated);
-                        });
-                    } catch (error) {
-                        console.error("실시간 메시지 처리 실패", error);
+                        } catch (error) {
+                            console.error("실시간 메시지 처리 실패", error);
+                        }
                     }
-                });
+                );
 
-                subscriptionRef.current = sub;
+                const readSub = await subscribeChatReadReceipt(
+                    selectedRoomId,
+                    (frame: IMessage) => {
+                        try {
+                            const receipt: ChatReadReceiptResponse = JSON.parse(frame.body);
+
+                            if (!receipt.read) return;
+                            if (receipt.roomId !== selectedRoomIdRef.current) return;
+
+                            setMessages((prev) =>
+                                prev.map((msg) => {
+                                    const isMyMessage =
+                                        currentUserIdRef.current !== null &&
+                                        msg.senderId === currentUserIdRef.current;
+
+                                    return isMyMessage ? { ...msg, read: true } : msg;
+                                })
+                            );
+
+                            setRooms((prev) =>
+                                prev.map((room) =>
+                                    room.roomId === receipt.roomId && room.lastMessageMine
+                                        ? { ...room, lastMessageRead: true }
+                                        : room
+                                )
+                            );
+                        } catch (error) {
+                            console.error("읽음 이벤트 처리 실패", error);
+                        }
+                    }
+                );
+
+                messageSubscriptionRef.current = messageSub;
+                readSubscriptionRef.current = readSub;
             } catch (error) {
                 console.error("채팅방 구독 실패", error);
             }
@@ -206,20 +286,24 @@ export default function ChatWidget() {
 
         return () => {
             cancelled = true;
-            cleanupSubscription();
+            cleanupSubscription(messageSubscriptionRef);
+            cleanupSubscription(readSubscriptionRef);
         };
     }, [isOpen, selectedRoomId]);
 
     const handleOpenToggle = () => {
         if (isOpen) {
             setInput("");
+            setMessages([]);
+            setView("list");
             closeChat();
         } else {
+            setView("list");
             openChat();
         }
     };
 
-    const handleSelectRoom = (roomId: number) => {
+    const handleSelectRoom = async (roomId: number) => {
         setRoom(roomId);
         setInput("");
         setMessages([]);
@@ -229,6 +313,14 @@ export default function ChatWidget() {
                 room.roomId === roomId ? { ...room, unreadCount: 0 } : room
             )
         );
+
+        setView("room");
+    };
+
+    const handleBack = async () => {
+        setView("list");
+        setInput("");
+        await fetchRooms();
     };
 
     const handleSend = async () => {
@@ -256,7 +348,10 @@ export default function ChatWidget() {
                             ? {
                                 ...room,
                                 lastMessage: trimmed,
-                                lastMessageTime: new Date().toISOString(),
+                                lastMessageAt: new Date().toISOString(),
+                                lastMessageMine: true,
+                                lastMessageRead: false,
+                                lastMessageSystem: false,
                             }
                             : room
                     )
@@ -272,12 +367,20 @@ export default function ChatWidget() {
         }
     };
 
+    const selectedRoom =
+        selectedRoomId !== null
+            ? rooms.find((room) => room.roomId === selectedRoomId) ?? null
+            : null;
+
     return (
         <>
             <ChatWindow
                 isOpen={isOpen}
+                view={view}
                 onClose={closeChat}
+                onBack={handleBack}
                 rooms={rooms}
+                selectedRoom={selectedRoom}
                 selectedRoomId={selectedRoomId}
                 onSelectRoom={handleSelectRoom}
                 messages={messages}

--- a/frontend/components/chat/ChatWindow.tsx
+++ b/frontend/components/chat/ChatWindow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import ChatInput from "./ChatInput";
 import ChatMessageBubble from "./ChatMessageBubble";
@@ -9,8 +9,11 @@ import { formatChatTime } from "../../app/lib/chatTime";
 
 interface ChatWindowProps {
     isOpen: boolean;
+    view: "list" | "room";
     onClose: () => void;
+    onBack: () => void;
     rooms: ChatRoomListResponse[];
+    selectedRoom: ChatRoomListResponse | null;
     selectedRoomId: number | null;
     onSelectRoom: (roomId: number) => void | Promise<void>;
     messages: ChatMessageResponse[];
@@ -23,10 +26,71 @@ interface ChatWindowProps {
     currentUserId?: number | null;
 }
 
+function formatRoomPreviewTime(value: string | null) {
+    if (!value) return "";
+
+    const date = new Date(value);
+    const now = new Date();
+
+    const sameDay =
+        date.getFullYear() === now.getFullYear() &&
+        date.getMonth() === now.getMonth() &&
+        date.getDate() === now.getDate();
+
+    if (sameDay) {
+        return new Intl.DateTimeFormat("ko-KR", {
+            hour: "numeric",
+            minute: "2-digit",
+        }).format(date);
+    }
+
+    return new Intl.DateTimeFormat("ko-KR", {
+        month: "numeric",
+        day: "numeric",
+    }).format(date);
+}
+
+function formatDateDivider(value: string) {
+    const date = new Date(value);
+    return new Intl.DateTimeFormat("ko-KR", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        weekday: "short",
+    }).format(date);
+}
+
+function isSameDay(a: string, b: string) {
+    const da = new Date(a);
+    const db = new Date(b);
+
+    return (
+        da.getFullYear() === db.getFullYear() &&
+        da.getMonth() === db.getMonth() &&
+        da.getDate() === db.getDate()
+    );
+}
+
+function isSameMinute(a: string, b: string) {
+    const da = new Date(a);
+    const db = new Date(b);
+
+    return (
+        da.getFullYear() === db.getFullYear() &&
+        da.getMonth() === db.getMonth() &&
+        da.getDate() === db.getDate() &&
+        da.getHours() === db.getHours() &&
+        da.getMinutes() === db.getMinutes()
+    );
+}
+
 export default function ChatWindow({
                                        isOpen,
+                                       view,
                                        onClose,
+                                       onBack,
                                        rooms,
+                                       selectedRoom,
                                        selectedRoomId,
                                        onSelectRoom,
                                        messages,
@@ -46,9 +110,24 @@ export default function ChatWindow({
     }, []);
 
     useEffect(() => {
-        if (!isOpen) return;
+        if (!isOpen || view !== "room") return;
         bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-    }, [messages, isOpen]);
+    }, [messages, isOpen, view]);
+
+    const renderedMessages = useMemo(() => {
+        return messages.map((msg, index) => {
+            const prev = messages[index - 1];
+
+            const showDateDivider = !prev || !isSameDay(prev.createdAt, msg.createdAt);
+            const showTime = !prev || !isSameMinute(prev.createdAt, msg.createdAt);
+
+            return {
+                ...msg,
+                showDateDivider,
+                showTime,
+            };
+        });
+    }, [messages]);
 
     if (!isOpen || !mounted) return null;
 
@@ -56,103 +135,172 @@ export default function ChatWindow({
         <div
             style={{
                 position: "fixed",
-                right: "24px",
-                bottom: "88px",
-                width: "380px",
-                height: "540px",
+                right: "16px",
+                bottom: "80px",
+                width: "calc(100vw - 32px)",
+                maxWidth: "380px",
+                height: "70vh",
+                maxHeight: "600px",
                 zIndex: 9999,
             }}
             className="flex flex-col overflow-hidden rounded-3xl border border-gray-200 bg-white shadow-2xl"
         >
             <div className="flex items-center justify-between border-b border-gray-100 bg-white px-5 py-4">
-                <div>
-                    <p className="text-sm font-semibold text-gray-900">1:1 채팅</p>
-                    <p className="text-xs text-gray-400">메시지를 주고받을 수 있습니다</p>
-                </div>
+                {view === "room" ? (
+                    <div className="flex min-w-0 items-center gap-3">
+                        <button
+                            type="button"
+                            onClick={onBack}
+                            className="text-lg text-gray-500 transition hover:text-gray-700"
+                            aria-label="목록으로 돌아가기"
+                        >
+                            ←
+                        </button>
+
+                        <div className="min-w-0">
+                            <p className="truncate text-sm font-semibold text-gray-900">
+                                {selectedRoom?.opponentNickname || "채팅"}
+                            </p>
+                            <p className="truncate text-xs text-gray-400">
+                                {selectedRoom?.projectName || "대화방"}
+                            </p>
+                        </div>
+                    </div>
+                ) : (
+                    <div>
+                        <p className="text-sm font-semibold text-gray-900">1:1 채팅</p>
+                        <p className="text-xs text-gray-400">대화할 상대를 선택하세요</p>
+                    </div>
+                )}
 
                 <button
                     type="button"
                     onClick={onClose}
                     className="text-xl text-gray-400 hover:text-gray-600"
+                    aria-label="채팅 닫기"
                 >
                     ×
                 </button>
             </div>
 
-            <div className="border-b border-gray-100 bg-white px-3 py-2">
-                <div className="flex max-h-[96px] flex-col gap-2 overflow-y-auto">
+            {view === "list" ? (
+                <div className="flex-1 overflow-y-auto bg-gray-50 px-3 py-3">
                     {loadingRooms ? (
-                        <div className="px-2 py-1 text-xs text-gray-400">
+                        <div className="flex h-full items-center justify-center text-sm text-gray-400">
                             채팅방 불러오는 중...
                         </div>
                     ) : rooms.length === 0 ? (
-                        <div className="px-2 py-1 text-xs text-gray-400">
-                            채팅방이 없습니다.
+                        <div className="flex h-full flex-col items-center justify-center text-center text-sm text-gray-400">
+                            <p>채팅방이 없습니다.</p>
+                            <p className="mt-1 text-xs">문의하기 버튼으로 대화를 시작해보세요.</p>
                         </div>
                     ) : (
-                        rooms.map((room) => (
-                            <button
-                                key={room.roomId}
-                                type="button"
-                                onClick={() => onSelectRoom(room.roomId)}
-                                className={`flex items-center justify-between rounded-xl border px-3 py-2 text-left transition ${
-                                    selectedRoomId === room.roomId
-                                        ? "border-violet-600 bg-violet-50"
-                                        : "border-gray-200 bg-white hover:bg-gray-50"
-                                }`}
-                            >
-                                <div className="min-w-0 flex-1">
-                                    <div className="truncate text-sm font-medium text-gray-900">
-                                        {room.opponentNickname}
-                                    </div>
-                                    <div className="truncate text-xs text-gray-400">
-                                        {room.lastMessage || "대화를 시작해보세요"}
-                                    </div>
-                                </div>
+                        <div className="space-y-2">
+                            {rooms.map((room) => (
+                                <button
+                                    key={room.roomId}
+                                    type="button"
+                                    onClick={() => onSelectRoom(room.roomId)}
+                                    className={`flex w-full items-start justify-between rounded-2xl border px-4 py-3 text-left transition ${
+                                        selectedRoomId === room.roomId
+                                            ? "border-violet-600 bg-violet-50"
+                                            : "border-gray-200 bg-white hover:bg-gray-50"
+                                    }`}
+                                >
+                                    <div className="min-w-0 flex-1">
+                                        <div className="flex items-center gap-2">
+                                            <p className="truncate text-sm font-semibold text-gray-900">
+                                                {room.opponentNickname}
+                                            </p>
 
-                                {room.unreadCount > 0 && (
-                                    <span className="ml-3 rounded-full bg-violet-600 px-2 py-0.5 text-[10px] text-white">
-                                        {room.unreadCount}
-                                    </span>
-                                )}
-                            </button>
-                        ))
+                                            {room.unreadCount > 0 && (
+                                                <span className="rounded-full bg-violet-600 px-2 py-0.5 text-[10px] font-medium text-white">
+                                                    {room.unreadCount}
+                                                </span>
+                                            )}
+                                        </div>
+
+                                        <p className="mt-1 truncate text-[11px] text-gray-500">
+                                            {room.projectName}
+                                        </p>
+
+                                        <div className="mt-1 flex items-center gap-1 text-xs text-gray-400">
+                                            {room.lastMessageMine && !room.lastMessageSystem && (
+                                                <span className={room.lastMessageRead ? "text-violet-600" : "text-gray-400"}>
+                                                    {room.lastMessageRead ? "읽음" : "전송됨"}
+                                                </span>
+                                            )}
+
+                                            {room.lastMessageSystem && (
+                                                <span className="text-gray-500">안내</span>
+                                            )}
+
+                                            <p className="truncate">
+                                                {room.lastMessage || "대화를 시작해보세요"}
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <div className="ml-3 shrink-0 pt-0.5 text-[11px] text-gray-400">
+                                        {formatRoomPreviewTime(room.lastMessageAt)}
+                                    </div>
+                                </button>
+                            ))}
+                        </div>
                     )}
                 </div>
-            </div>
+            ) : (
+                <>
+                    <div className="flex-1 overflow-y-auto bg-gray-50 px-4 py-4">
+                        {loadingMessages ? (
+                            <div className="flex h-full items-center justify-center text-sm text-gray-400">
+                                메시지를 불러오는 중...
+                            </div>
+                        ) : messages.length === 0 ? (
+                            <div className="flex h-full flex-col items-center justify-center text-center text-sm text-gray-400">
+                                <p>아직 메시지가 없습니다.</p>
+                                <p className="mt-1 text-xs">첫 메시지를 보내보세요.</p>
+                            </div>
+                        ) : (
+                            <div className="space-y-3">
+                                {renderedMessages.map((msg) => (
+                                    <div key={msg.messageId} className="space-y-2">
+                                        {msg.showDateDivider && (
+                                            <div className="flex justify-center py-1">
+                                                <div className="rounded-full bg-gray-200 px-3 py-1 text-[11px] text-gray-600">
+                                                    {formatDateDivider(msg.createdAt)}
+                                                </div>
+                                            </div>
+                                        )}
 
-            <div className="flex-1 space-y-3 overflow-y-auto bg-gray-50 px-4 py-4">
-                {loadingMessages ? (
-                    <div className="flex h-full items-center justify-center text-sm text-gray-400">
-                        메시지를 불러오는 중...
+                                        <ChatMessageBubble
+                                            message={msg.content}
+                                            time={msg.showTime ? formatChatTime(msg.createdAt) : ""}
+                                            isMine={
+                                                currentUserId !== null &&
+                                                msg.senderId === currentUserId
+                                            }
+                                            isRead={msg.read}
+                                            senderNickname={msg.senderNickname}
+                                            systemMessage={msg.systemMessage}
+                                        />
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                        <div ref={bottomRef} />
                     </div>
-                ) : messages.length === 0 ? (
-                    <div className="flex h-full flex-col items-center justify-center text-center text-sm text-gray-400">
-                        <p>아직 메시지가 없습니다.</p>
-                        <p className="mt-1 text-xs">첫 메시지를 보내보세요.</p>
-                    </div>
-                ) : (
-                    messages.map((msg) => (
-                        <ChatMessageBubble
-                            key={msg.messageId}
-                            message={msg.content}
-                            time={formatChatTime(msg.createdAt)}
-                            isMine={currentUserId !== null && msg.senderId === currentUserId}
-                            senderNickname={msg.senderNickname}
-                        />
-                    ))
-                )}
-                <div ref={bottomRef} />
-            </div>
 
-            <ChatInput
-                value={input}
-                onChange={onChangeInput}
-                onSend={onSend}
-                disabled={sending || !selectedRoomId}
-                sending={sending}
-                canSend={!!selectedRoomId}
-            />
+                    <ChatInput
+                        value={input}
+                        onChange={onChangeInput}
+                        onSend={onSend}
+                        disabled={sending || !selectedRoomId}
+                        sending={sending}
+                        canSend={!!selectedRoomId}
+                    />
+                </>
+            )}
         </div>,
         document.body
     );

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -32,6 +32,16 @@ export interface ChatRoomListResponse {
     opponentName: string;
     opponentNickname: string;
     lastMessage: string | null;
-    lastMessageTime: string | null;
+    lastMessageAt: string | null;
     unreadCount: number;
+
+    lastMessageMine: boolean;
+    lastMessageRead: boolean;
+    lastMessageSystem: boolean;
+}
+
+export interface ChatReadReceiptResponse {
+    roomId: number;
+    readerId: number;
+    read: boolean;
 }


### PR DESCRIPTION

## 🔎 What

- 채팅 위젯 UI를 목록/대화 화면 전환형 구조로 개선
- 채팅방 목록에 마지막 메시지 / 시간 / unread badge 표시 추가
- 메시지 말풍선에 읽음/전송됨 표시 추가
- 실시간 읽음 반영 기능 추가
- 메시지 영역에 날짜 구분선 / 시간 그룹핑 적용
- 채팅방 목록 정렬 안정화 및 반응형 위젯 크기 적용
- 빈 채팅방 숨김 처리로 목록 UX 개선

## 🔗 Issue

- Closes: #164

## ✅ 체크리스트

- [ ] 브랜치 base가 적절한가요?
- [ ] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added read receipts—see when your messages are read in real-time
  * Introduced system messages with distinct visual styling
  * Enabled Shift+Enter for multi-line messages in chat input

* **Improvements**
  * Enhanced chat room list with last message previews and read status indicators
  * Added date dividers and timestamps for better message organization
  * Streamlined chat connectivity and room management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->