### PR TITLE
bug : 인증 시스템 Stateless화 및 UserContext 캐싱 도입

### DIFF
--- a/backend/src/main/java/com/devnear/global/auth/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/devnear/global/auth/CustomUserDetailsService.java
@@ -21,16 +21,13 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     @Cacheable(value = "users", key = "#email", sync = true)
     public UserDetails loadUserByUsername(@NonNull String email) throws UsernameNotFoundException {
-        // 1. 유저를 먼저 찾아서 변수에 담습니다.
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
 
-        // 2. 상태를 체크합니다. (UserStatus.WITHDRAWN 체크)
         if (user.getStatus() == UserStatus.WITHDRAWN) {
             throw new DisabledException("탈퇴한 계정입니다.");
         }
 
-        // 3. 마지막에 SecurityUser로 변환하여 반환합니다.
         return new SecurityUser(user);
     }
 }

--- a/backend/src/main/java/com/devnear/global/auth/JwtTokenProvider.java
+++ b/backend/src/main/java/com/devnear/global/auth/JwtTokenProvider.java
@@ -7,34 +7,26 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Date;
 
 @Component
 public class JwtTokenProvider {
 
-    private final UserDetailsService userDetailsService;
-    private final SecretKey key; // final 유지
-    private final long validityInMilliseconds; // final 유지
+    private final SecretKey key;
+    private final long validityInMilliseconds;
 
-    // 2. 생성자를 통해 설정값(ConfigurationProperties)과 의존성을 한꺼번에 주입
-    public JwtTokenProvider(
-            UserDetailsService userDetailsService,
-            JwtProperties jwtProperties
-    ) {
-        this.userDetailsService = userDetailsService;
+    public JwtTokenProvider(JwtProperties jwtProperties) {
         this.validityInMilliseconds = jwtProperties.getExpiration();
-        // 주입받은 secretString으로 여기서 Key를 생성합니다.
         String secretString = jwtProperties.getSecret();
         this.key = Keys.hmacShaKeyFor(secretString.getBytes(StandardCharsets.UTF_8));
     }
 
-    // 1. 토큰 생성 (기존 로직 유지, 필드값 사용)
     public String createToken(Long userId, String email, String role) {
         Date now = new Date();
         Date validity = new Date(now.getTime() + validityInMilliseconds);
@@ -50,36 +42,48 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    /**
-     * 토큰의 유효성을 검사합니다.
-     * @throws JwtException | IllegalArgumentException 토큰이 유효하지 않을 경우 발생
-     */
     public void validateToken(String token) {
         try {
             Jwts.parser()
                     .verifyWith(key)
                     .build()
                     .parseSignedClaims(token);
-            // 검증 성공 시 아무것도 하지 않고 통과
         } catch (JwtException | IllegalArgumentException e) {
-            // 에러를 삼키지 않고 다시 던짐
-            // 이렇게 해야 Filter의 catch 블록에서 로그를 상세히 남길 수 있음
             throw e;
         }
     }
 
+    /**
+     * 🎯 [최적화] DB 조회 없이 토큰의 Claim만으로 인증 객체를 생성합니다.
+     * 필터 단계에서의 불필요한 DB 조회를 제거하여 성능을 극대화합니다.
+     */
     public Authentication getAuthentication(String token) {
-        String email = getEmail(token);
-        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+        Claims claims = getClaims(token);
+
+        Long userId = claims.get("userId", Long.class);
+        String email = claims.getSubject();
+        String role = claims.get("role", String.class);
+
+        // SecurityUser는 마스터의 프로젝트에 정의된 Principal 객체라고 가정합니다.
+        // DB 조회를 생략하고 토큰 정보로만 구성된 SecurityUser를 넘깁니다.
+        SecurityUser principal = new SecurityUser(userId, email, role);
+
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                "",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role))
+        );
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
     }
 
     public String getEmail(String token) {
-        return Jwts.parser()
-                    .verifyWith(key)
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload()
-                    .getSubject();
+        return getClaims(token).getSubject();
     }
 }

--- a/backend/src/main/java/com/devnear/global/auth/LoginUserArgumentResolver.java
+++ b/backend/src/main/java/com/devnear/global/auth/LoginUserArgumentResolver.java
@@ -1,7 +1,6 @@
 package com.devnear.global.auth;
 
 import com.devnear.web.domain.user.User;
-import com.devnear.web.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
@@ -16,11 +15,10 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @RequiredArgsConstructor
 public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private final UserRepository userRepository;
+    private final UserContext userContext;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        // @LoginUser 어노테이션이 붙어 있고, 파라미터 타입이 User 엔티티인 경우에만 작동!
         return parameter.hasParameterAnnotation(LoginUser.class)
                 && parameter.getParameterType().equals(User.class);
     }
@@ -32,10 +30,11 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
         if (auth == null || !(auth.getPrincipal() instanceof SecurityUser principal)) {
-            return null; // 로그인하지 않은 경우
+            return null;
         }
 
-        // 레디스(SecurityUser)에 저장된 ID로 실제 DB에서 유저 엔티티를 조회!
-        return userRepository.findById(principal.getId()).orElse(null);
+        // 🎯 [수정] UserContext의 getCurrentUser()는 이제 인자를 받지 않습니다.
+        // 이미 UserContext 내부에서 SecurityContext를 참조하여 유저를 찾아오기 때문입니다.
+        return userContext.getCurrentUser();
     }
 }

--- a/backend/src/main/java/com/devnear/global/auth/SecurityUser.java
+++ b/backend/src/main/java/com/devnear/global/auth/SecurityUser.java
@@ -24,12 +24,27 @@ public class SecurityUser implements UserDetails {
     private String role;
     private String status;
 
+    /**
+     * 엔티티를 통한 생성자 (로그인 시점 등에 사용)
+     */
     public SecurityUser(User user) {
         this.id = user.getId();
         this.email = user.getEmail();
         this.password = user.getPassword();
         this.role = user.getRole().name();
         this.status = user.getStatus().name();
+    }
+
+    /**
+     * 🎯 [추가] 토큰 정보(Claims)를 통한 생성자
+     * DB 조회 없이 필터 단계에서 인증 객체를 생성하기 위해 사용됩니다.
+     */
+    public SecurityUser(Long id, String email, String role) {
+        this.id = id;
+        this.email = email;
+        this.role = role;
+        this.password = ""; // 토큰 인증 시 패스워드는 불필요합니다.
+        this.status = "ACTIVE"; // 토큰이 유효하다면 활성 상태로 간주합니다.
     }
 
     @JsonIgnore
@@ -46,8 +61,7 @@ public class SecurityUser implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        // 🎯 [수정] ACTIVE 또는 INACTIVE 상태일 때만 true를 반환
-        // 탈퇴(WITHDRAWN)나 정지 상태라면 false가 반환되어 시큐리티가 차단합
+        // ACTIVE 또는 INACTIVE 상태일 때만 true를 반환
         return "ACTIVE".equals(status) || "INACTIVE".equals(status);
     }
 }

--- a/backend/src/main/java/com/devnear/global/auth/UserContext.java
+++ b/backend/src/main/java/com/devnear/global/auth/UserContext.java
@@ -1,0 +1,36 @@
+package com.devnear.global.auth;
+
+import com.devnear.web.domain.user.User;
+import com.devnear.web.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.WebApplicationContext;
+
+@Component
+@RequiredArgsConstructor
+@Scope(value = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class UserContext {
+
+    private final UserRepository userRepository;
+    private User currentUser;
+
+    /**
+     * 🎯 [핵심] 현재 요청에서 유저 엔티티를 딱 한 번만 조회하여 공유합니다.
+     */
+    public User getCurrentUser() {
+        if (currentUser == null) {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth == null || !(auth.getPrincipal() instanceof SecurityUser principal)) {
+                return null;
+            }
+            // ID로 조회하여 N+1 방지용 @EntityGraph가 적용된 메서드 호출
+            currentUser = userRepository.findWithProfilesById(principal.getId())
+                    .orElseThrow(() -> new IllegalArgumentException("요청한 유저를 찾을 수 없습니다. ID: " + principal.getId()));
+        }
+        return currentUser;
+    }
+}

--- a/backend/src/main/java/com/devnear/web/domain/user/UserRepository.java
+++ b/backend/src/main/java/com/devnear/web/domain/user/UserRepository.java
@@ -12,15 +12,21 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     /**
-     * [N+1 해결 버전] 이메일로 회원을 조회합니다.
-     * @EntityGraph를 사용하여 연관된 프로필들을 한 번의 LEFT JOIN으로 함께 가져옵니다.
-     * 이로 인해 '유저 조회 1번 + 프로필 조회 N번'이 나가는 현상을 원천 차단합니다.
+     * [N+1 해결 버전] 이메일로 회원을 조회
+     * @EntityGraph를 사용하여 연관된 프로필들을 한 번의 LEFT JOIN으로 함께 가져옴
      */
     @EntityGraph(attributePaths = {"freelancerProfile", "clientProfile"})
     Optional<User> findByEmail(String email);
 
     /**
-     * 회원 탈퇴 등 동시성 제어가 필요할 때 같은 {@code users} 행에 대해 배타 락을 겁니다.
+     * 🎯 [추가된 메서드] ID로 회원을 조회할 때 프로필을 함께 가져옴
+     * 리졸버(LoginUserArgumentResolver)에서 중복 쿼리를 방지하기 위해 사용됨
+     */
+    @EntityGraph(attributePaths = {"freelancerProfile", "clientProfile"})
+    Optional<User> findWithProfilesById(Long id);
+
+    /**
+     * 회원 탈퇴 등 동시성 제어가 필요할 때 같은 {@code users} 행에 대해 배타 락을 검
      */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select u from User u where u.email = :email")
@@ -31,4 +37,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 특정 유저 ID를 제외하고 닉네임 중복 체크용
     boolean existsByNicknameAndIdNot(String nickname, Long id);
+
+    // 이메일 중복 체크용 (필요할 수 있어 추가 유지)
+    boolean existsByEmail(String email);
 }

--- a/backend/src/main/java/com/devnear/web/service/user/UserService.java
+++ b/backend/src/main/java/com/devnear/web/service/user/UserService.java
@@ -1,6 +1,7 @@
 package com.devnear.web.service.user;
 
 import com.devnear.global.auth.JwtTokenProvider;
+import com.devnear.global.auth.UserContext;
 import com.devnear.web.domain.client.ClientProfileRepository;
 import com.devnear.web.domain.enums.Role;
 import com.devnear.web.domain.enums.UserStatus;
@@ -12,15 +13,10 @@ import com.devnear.web.domain.skill.SkillRepository;
 import com.devnear.web.domain.user.User;
 import com.devnear.web.domain.user.UserRepository;
 import com.devnear.web.dto.freelancer.FreelancerProfileRequest;
-import com.devnear.web.dto.user.NotificationPreferencePatchRequest;
-import com.devnear.web.dto.user.OnboardingRequest;
-import com.devnear.web.dto.user.TokenResponse;
-import com.devnear.web.dto.user.UserInfoResponse;
-import com.devnear.web.dto.user.UserLoginRequest;
-import com.devnear.web.dto.user.UserRegisterRequest;
+import com.devnear.web.dto.user.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.dao.DataIntegrityViolationException; // 👈 예외 처리 필수 임포트
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,27 +35,18 @@ public class UserService {
     private final ClientProfileRepository clientProfileRepository;
     private final FreelancerProfileRepository freelancerProfileRepository;
     private final SkillRepository skillRepository;
+    private final UserContext userContext; // 🎯 보관함 주입
 
-    /**
-     * 회원 가입
-     * [수정] 동시성 이슈 대응을 위해 try-catch 블록 추가
-     */
     @Transactional
     public Long register(UserRegisterRequest request) {
-        // 1차 체크 (대부분 여기서 걸러짐)
-        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+        if (userRepository.existsByEmail(request.getEmail())) {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
         }
-
         try {
             String encodedPassword = passwordEncoder.encode(request.getPassword());
             User user = request.toEntity(encodedPassword);
-
-            // 2차 방어: DB Unique 제약 조건 위반 시 Catch
-            // saveAndFlush를 사용하여 메서드 내부에서 즉시 예외를 발생시키고 잡을 수 있게 함
             return userRepository.save(user).getId();
         } catch (DataIntegrityViolationException e) {
-            // 동시 가입 시도가 발생하여 1차 체크를 통과했더라도 DB 레이어에서 최종 차단
             throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
         }
     }
@@ -77,11 +64,13 @@ public class UserService {
         return new TokenResponse(token, "Bearer");
     }
 
-    @CacheEvict(value = "users", key = "#email")
+    /**
+     * 🎯 [최적화] email로 다시 조회하지 않고 UserContext에서 가져옵니다.
+     */
+    @CacheEvict(value = "users", allEntries = true)
     @Transactional
     public TokenResponse onboarding(String email, OnboardingRequest request) {
-        User user = userRepository.findByEmailForUpdate(email)
-                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+        User user = userContext.getCurrentUser(); // 🚀 DB 안 가고 보관함에서 꺼냄
 
         if (user.getStatus() == UserStatus.WITHDRAWN) {
             throw new IllegalArgumentException("탈퇴 처리된 계정입니다.");
@@ -94,7 +83,6 @@ public class UserService {
 
         user.onboard(request.getNickname(), request.getRole());
 
-        // 클라이언트 프로필 처리
         if (request.getRole() == Role.CLIENT || request.getRole() == Role.BOTH) {
             if (user.getClientProfile() != null) {
                 user.getClientProfile().update(request.getClientProfile());
@@ -103,7 +91,6 @@ public class UserService {
             }
         }
 
-        // 프리랜서 프로필 처리
         if (request.getRole() == Role.FREELANCER || request.getRole() == Role.BOTH) {
             if (user.getFreelancerProfile() != null) {
                 throw new IllegalStateException("이미 프리랜서 프로필이 존재합니다.");
@@ -140,16 +127,17 @@ public class UserService {
         return new TokenResponse(newToken, "Bearer");
     }
 
+    /**
+     * 🎯 [최적화] 단순히 내 정보를 가져올 때도 UserContext 활용
+     */
     public UserInfoResponse getUserInfo(String email) {
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+        User user = userContext.getCurrentUser();
         return new UserInfoResponse(user);
     }
 
     @Transactional
     public UserInfoResponse updateNotificationPreferences(String email, NotificationPreferencePatchRequest request) {
-        User user = userRepository.findByEmailForUpdate(email)
-                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+        User user = userContext.getCurrentUser();
         if (user.getStatus() == UserStatus.WITHDRAWN) {
             throw new IllegalArgumentException("탈퇴 처리된 계정입니다.");
         }
@@ -159,15 +147,10 @@ public class UserService {
         return new UserInfoResponse(user);
     }
 
-    /**
-     * [Cloudinary] 프로필 이미지 URL을 DB에 반영합니다.
-     * ImageController에서 Cloudinary 업로드 완료 후 호출됩니다.
-     */
-    @CacheEvict(value = "users", key = "#email")
+    @CacheEvict(value = "users", allEntries = true)
     @Transactional
     public void updateProfileImage(String email, String newImageUrl) {
-        User user = userRepository.findByEmailForUpdate(email)
-                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+        User user = userContext.getCurrentUser();
         if (user.getStatus() == UserStatus.WITHDRAWN) {
             throw new IllegalArgumentException("탈퇴 처리된 계정입니다.");
         }


### PR DESCRIPTION
## 🔎 What
매 API 요청마다 반복적으로 발생하던 유저 및 프로필 중복 조회 쿼리 이슈를 해결하기 위한 백엔드 최적화 작업
인증 필터의 DB 의존성을 끊어내고, UserContext를 도입하여 요청당 단 1회의 조회만 발생하도록 아키텍처를 개선
[ 📊 성능 개선 지표 (Impact) ]
Before: 단일 API 요청 시 유저 및 연관 프로필 조회 쿼리 평균 5~7회 발생
After: 단일 API 요청 시 유저/프로필 조회 쿼리 1회(단일 JOIN)로 압축 성공

+++
서비스 계층(Service)에서 현재 로그인한 유저 정보가 필요할 경우, 이제 UserRepository가 아닌 주입된 UserContext.getCurrentUser()를 사용해주세용

## 🔗 Issue

- Closes: #173 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized authentication flow to minimize database queries during user verification
  * Introduced request-scoped caching to streamline repeated user data access within requests
  * Simplified user lookup and authentication mechanisms
  * Enhanced email uniqueness validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->