### PR TITLE
[Feat]Hide-widget-upon-leaving-1-1-chat-or-logging-out-

### DIFF
--- a/backend/src/main/java/com/devnear/web/controller/chat/ChatController.java
+++ b/backend/src/main/java/com/devnear/web/controller/chat/ChatController.java
@@ -77,4 +77,14 @@ public class ChatController {
 
         return ResponseEntity.noContent().build();
     }
+
+    @Operation(summary = "채팅방 나가기")
+    @DeleteMapping("/rooms/{roomId}")
+    public ResponseEntity<Void> leaveRoom(
+            @LoginUser User user,
+            @PathVariable Long roomId
+    ) {
+        chatService.leaveRoom(user, roomId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/com/devnear/web/domain/chat/ChatRoom.java
+++ b/backend/src/main/java/com/devnear/web/domain/chat/ChatRoom.java
@@ -93,16 +93,20 @@ public class ChatRoom extends BaseTimeEntity {
             return user2Exited;
         }
 
-        return true;
+        throw new IllegalArgumentException("User is not a participant: " + user.getId());
     }
 
-    public void restoreFor(User userA, User userB) {
-        if (user1.getId().equals(userA.getId()) || user1.getId().equals(userB.getId())) {
+    public void restoreFor(User initiator) {
+        if (user1.getId().equals(initiator.getId())) {
             this.user1Exited = false;
+            return;
         }
 
-        if (user2.getId().equals(userA.getId()) || user2.getId().equals(userB.getId())) {
+        if (user2.getId().equals(initiator.getId())) {
             this.user2Exited = false;
+            return;
         }
+
+        throw new IllegalArgumentException("User is not a participant: " + initiator.getId());
     }
 }

--- a/backend/src/main/java/com/devnear/web/domain/chat/ChatRoom.java
+++ b/backend/src/main/java/com/devnear/web/domain/chat/ChatRoom.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 @Table(
         name = "chat_rooms",
         uniqueConstraints = {
-                // 같은 프로젝트 안에서 같은 두 유저가 중복 채팅방을 만들지 못하게 막는 제약조건
                 @UniqueConstraint(
                         name = "uk_chat_room_project_users",
                         columnNames = {"project_id", "user1_id", "user2_id"}
@@ -29,37 +28,37 @@ public class ChatRoom extends BaseTimeEntity {
     @Column(name = "chat_room_id")
     private Long id;
 
-    // 채팅 참여자 1
-    // User 기준으로 채팅방을 관리해야 인증/권한 체크가 쉬움
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user1_id", nullable = false)
     private User user1;
 
-    // 채팅 참여자 2
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user2_id", nullable = false)
     private User user2;
 
-    // 어떤 프로젝트에 대한 채팅인지 연결
-    // DevNear는 프로젝트 기반 상담 구조라서 project 연결이 중요함
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id", nullable = false)
     private Project project;
+
+    @Column(name = "user1_exited", nullable = false)
+    private boolean user1Exited = false;
+
+    @Column(name = "user2_exited", nullable = false)
+    private boolean user2Exited = false;
 
     @Builder
     public ChatRoom(User user1, User user2, Project project) {
         this.user1 = user1;
         this.user2 = user2;
         this.project = project;
+        this.user1Exited = false;
+        this.user2Exited = false;
     }
 
-    // 현재 로그인한 사용자가 이 채팅방의 참여자인지 확인하는 메서드
     public boolean isParticipant(User user) {
         return user1.getId().equals(user.getId()) || user2.getId().equals(user.getId());
     }
 
-    // 내 기준에서 상대방이 누구인지 찾아주는 메서드
-    // 채팅방 목록에서 "상대방 이름" 보여줄 때 사용
     public User getOpponent(User me) {
         if (user1.getId().equals(me.getId())) {
             return user2;
@@ -68,7 +67,42 @@ public class ChatRoom extends BaseTimeEntity {
             return user1;
         }
 
-        // 참여자가 아닌 유저가 접근한 경우 예외 발생
         throw new IllegalArgumentException("해당 유저는 이 채팅방의 참여자가 아닙니다.");
+    }
+
+    public void exit(User user) {
+        if (user1.getId().equals(user.getId())) {
+            this.user1Exited = true;
+            return;
+        }
+
+        if (user2.getId().equals(user.getId())) {
+            this.user2Exited = true;
+            return;
+        }
+
+        throw new IllegalArgumentException("해당 유저는 이 채팅방의 참여자가 아닙니다.");
+    }
+
+    public boolean isExited(User user) {
+        if (user1.getId().equals(user.getId())) {
+            return user1Exited;
+        }
+
+        if (user2.getId().equals(user.getId())) {
+            return user2Exited;
+        }
+
+        return true;
+    }
+
+    public void restoreFor(User userA, User userB) {
+        if (user1.getId().equals(userA.getId()) || user1.getId().equals(userB.getId())) {
+            this.user1Exited = false;
+        }
+
+        if (user2.getId().equals(userA.getId()) || user2.getId().equals(userB.getId())) {
+            this.user2Exited = false;
+        }
     }
 }

--- a/backend/src/main/java/com/devnear/web/service/chat/ChatService.java
+++ b/backend/src/main/java/com/devnear/web/service/chat/ChatService.java
@@ -104,7 +104,7 @@ public class ChatService {
             User freelancerUser
     ) {
         validateProjectClientAndPair(project, clientUser, freelancerUser);
-        return resolveOrCreateChatRoom(project, clientUser, freelancerUser, null);
+        return resolveOrCreateChatRoom(project, clientUser, freelancerUser, null, null);
     }
 
     @Transactional
@@ -117,7 +117,7 @@ public class ChatService {
         validateProjectClientAndPair(project, clientUser, freelancerUser);
 
         AtomicBoolean createdNew = new AtomicBoolean(false);
-        ChatRoom room = resolveOrCreateChatRoom(project, clientUser, freelancerUser, createdNew);
+        ChatRoom room = resolveOrCreateChatRoom(project, clientUser, freelancerUser, actingUser, createdNew);
 
         if (createdNew.get()) {
             User recipient = actingUser.getId().equals(clientUser.getId()) ? freelancerUser : clientUser;
@@ -150,7 +150,7 @@ public class ChatService {
 
     private ChatRoomResponse createOrGetRoom(User me, User target, Project project) {
         AtomicBoolean createdNew = new AtomicBoolean(false);
-        ChatRoom room = resolveOrCreateChatRoom(project, me, target, createdNew);
+        ChatRoom room = resolveOrCreateChatRoom(project, me, target, me, createdNew);
 
         if (createdNew.get()) {
             notificationService.notifyUser(
@@ -189,6 +189,7 @@ public class ChatService {
             Project project,
             User userA,
             User userB,
+            User initiator,
             AtomicBoolean createdFlag
     ) {
         User first = userA.getId() < userB.getId() ? userA : userB;
@@ -215,7 +216,9 @@ public class ChatService {
                         .orElseThrow(() -> e);
             }
         } else {
-            room.restoreFor(userA, userB);
+            if (initiator != null) {
+                room.restoreFor(initiator);
+            }
         }
 
         return room;

--- a/backend/src/main/java/com/devnear/web/service/chat/ChatService.java
+++ b/backend/src/main/java/com/devnear/web/service/chat/ChatService.java
@@ -51,11 +51,6 @@ public class ChatService {
     private final NotificationService notificationService;
     private final ApplicationEventPublisher eventPublisher;
 
-    /**
-     * 채팅방 생성/조회 정책
-     * 1) 프리랜서 -> 클라이언트 문의: 허용
-     * 2) 클라이언트 -> 프리랜서: 해당 프로젝트로 역제안을 보낸 경우만 허용
-     */
     @Transactional
     public ChatRoomResponse createRoom(User me, ChatRoomCreateRequest request) {
         if (me.getId().equals(request.getTargetUserId())) {
@@ -77,14 +72,12 @@ public class ChatService {
         boolean meIsClient = me.getId().equals(clientUserId);
         boolean targetIsClient = target.getId().equals(clientUserId);
 
-        // 1. 프리랜서 -> 클라이언트 문의 허용
         if (!meIsClient && targetIsClient) {
             freelancerProfileRepository.findByUser_Id(me.getId())
                     .orElseThrow(() -> new ChatAccessDeniedException("프리랜서만 프로젝트 문의 채팅을 시작할 수 있습니다."));
             return createOrGetRoom(me, target, project);
         }
 
-        // 2. 클라이언트 -> 프리랜서 채팅은 역제안이 있는 경우만 허용
         if (meIsClient && !targetIsClient) {
             FreelancerProfile freelancerProfile = freelancerProfileRepository.findByUser_Id(target.getId())
                     .orElseThrow(() -> new ResourceNotFoundException("프리랜서 프로필을 찾을 수 없습니다."));
@@ -104,10 +97,6 @@ public class ChatService {
         throw new ChatAccessDeniedException("채팅방을 생성할 수 없습니다.");
     }
 
-    /**
-     * 프로젝트 등록 클라이언트와 지정 프리랜서 간 채팅방을 조회하거나 생성합니다.
-     * 제안(Proposal) 문의 등, 아직 프로젝트에 프리랜서가 배정되지 않은 경우에도 사용합니다.
-     */
     @Transactional
     public ChatRoom resolveOrCreateChatRoomForClientAndFreelancer(
             Project project,
@@ -118,9 +107,6 @@ public class ChatService {
         return resolveOrCreateChatRoom(project, clientUser, freelancerUser, null);
     }
 
-    /**
-     * 위 메서드와 동일하되, 호출자 기준 ChatRoomResponse로 반환합니다.
-     */
     @Transactional
     public ChatRoomResponse getOrCreateRoomForProjectClientAndFreelancer(
             User actingUser,
@@ -179,9 +165,6 @@ public class ChatService {
         return ChatRoomResponse.from(room, me);
     }
 
-    /**
-     * 시스템 안내 메시지를 저장하고, 구독 중인 클라이언트에 웹소켓으로 전달합니다.
-     */
     @Transactional
     public ChatMessageResponse saveSystemMessageAndBroadcast(ChatRoom room, User technicalSender, String content) {
         if (content == null || content.isBlank()) {
@@ -231,19 +214,23 @@ public class ChatService {
                 room = chatRoomRepository.findByProjectAndUser1AndUser2(project, first, second)
                         .orElseThrow(() -> e);
             }
+        } else {
+            room.restoreFor(userA, userB);
         }
 
         return room;
     }
 
     public List<ChatRoomListResponse> getMyRooms(User me) {
-        List<ChatRoom> rooms = chatRoomRepository.findAllByUser1OrUser2OrderByUpdatedAtDesc(me, me);
+        List<ChatRoom> rooms = chatRoomRepository.findAllByUser1OrUser2OrderByUpdatedAtDesc(me, me)
+                .stream()
+                .filter(room -> !room.isExited(me))
+                .toList();
 
         if (rooms.isEmpty()) {
             return List.of();
         }
 
-        // 같은 상대와의 여러 방이 있더라도 최신 방 하나만 목록에 노출
         Map<Long, ChatRoom> latestRoomByOpponentId = new LinkedHashMap<>();
         for (ChatRoom room : rooms) {
             Long opponentId = room.getOpponent(me).getId();
@@ -312,6 +299,12 @@ public class ChatService {
     }
 
     @Transactional
+    public void leaveRoom(User me, Long roomId) {
+        ChatRoom room = getValidatedRoom(me, roomId);
+        room.exit(me);
+    }
+
+    @Transactional
     public ChatMessageResponse saveMessage(User me, ChatMessageSendRequest request) {
         ChatRoom room = getValidatedRoom(me, request.getRoomId());
 
@@ -336,6 +329,10 @@ public class ChatService {
 
         if (!room.isParticipant(me)) {
             throw new ChatAccessDeniedException("해당 채팅방에 접근할 권한이 없습니다.");
+        }
+
+        if (room.isExited(me)) {
+            throw new ChatAccessDeniedException("나간 채팅방에는 접근할 수 없습니다.");
         }
 
         return room;

--- a/frontend/app/hooks/useProjectDetail.ts
+++ b/frontend/app/hooks/useProjectDetail.ts
@@ -23,6 +23,8 @@ export interface ProjectDetail {
     latitude?: number;
     longitude?: number;
     skills: SkillItem[];
+
+    // 채팅 상대 후보 필드들
     clientUserId?: number;
     userId?: number;
     clientId?: number;
@@ -38,6 +40,7 @@ function isAbortError(err: unknown): boolean {
 
 export function useProjectDetail(projectId: number | null) {
     const openChat = useChatStore((state) => state.openChat);
+
     const [project, setProject] = useState<ProjectDetail | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -49,8 +52,8 @@ export function useProjectDetail(projectId: number | null) {
     const [message, setMessage] = useState('');
     const [submitting, setSubmitting] = useState(false);
     const [refetchTick, setRefetchTick] = useState(0);
+
     const prevProjectIdRef = useRef<number | null>(null);
-    /** 같은 projectId에서 refetch 시 사용자가 수정한 bidPrice를 덮어쓰지 않도록, 시드한 프로젝트 id만 기록 */
     const bidPriceSeededForProjectIdRef = useRef<number | null>(null);
 
     const refetch = useCallback(() => {
@@ -83,6 +86,7 @@ export function useProjectDetail(projectId: number | null) {
             setIsApplied(false);
             setIsBookmarked(false);
         }
+
         setLoading(true);
         setError(null);
         setIsApplyOpen(false);
@@ -91,30 +95,44 @@ export function useProjectDetail(projectId: number | null) {
         void (async () => {
             try {
                 const response = await api.get(`/v1/projects/${projectId}`, { signal });
+
                 if (signal.aborted) return;
+
                 setProject(response.data);
+
                 if (bidPriceSeededForProjectIdRef.current !== projectId) {
                     setBidPrice(String(response.data.budget ?? ''));
                     bidPriceSeededForProjectIdRef.current = projectId;
                 }
             } catch (err: unknown) {
                 if (signal.aborted || isAbortError(err)) return;
+
                 const status = (err as { response?: { status?: number } })?.response?.status;
+
                 if (status !== 401) {
                     setError('프로젝트 정보를 불러오는데 실패했습니다.');
                 } else {
                     setError(null);
                 }
+
                 setLoading(false);
                 return;
             }
 
             const token = localStorage.getItem('accessToken');
+
             if (token) {
                 try {
                     const myApps = await api.get('/applications/me', { signal });
+
                     if (signal.aborted) return;
-                    setIsApplied(myApps.data.some((app: { projectId?: number }) => app.projectId === Number(projectId)));
+
+                    setIsApplied(
+                        myApps.data.some(
+                            (app: { projectId?: number }) =>
+                                app.projectId === Number(projectId)
+                        )
+                    );
                 } catch (err: unknown) {
                     if (signal.aborted || isAbortError(err)) return;
                     setIsApplied(false);
@@ -122,9 +140,17 @@ export function useProjectDetail(projectId: number | null) {
 
                 try {
                     const myBookmarks = await api.get('/v1/bookmarks/projects?size=1000', { signal });
+
                     if (signal.aborted) return;
+
                     const bookmarkList = myBookmarks.data.content || [];
-                    setIsBookmarked(bookmarkList.some((b: { projectId?: number }) => b.projectId === Number(projectId)));
+
+                    setIsBookmarked(
+                        bookmarkList.some(
+                            (b: { projectId?: number }) =>
+                                b.projectId === Number(projectId)
+                        )
+                    );
                 } catch (err: unknown) {
                     if (signal.aborted || isAbortError(err)) return;
                     setIsBookmarked(false);
@@ -145,6 +171,7 @@ export function useProjectDetail(projectId: number | null) {
 
     const toggleBookmark = useCallback(async () => {
         if (!projectId) return;
+
         try {
             if (isBookmarked) {
                 await api.delete(`/v1/bookmarks/projects/${projectId}`);
@@ -158,56 +185,94 @@ export function useProjectDetail(projectId: number | null) {
         }
     }, [isBookmarked, projectId]);
 
-    const startChat = useCallback(async (onSuccess?: () => void) => {
-        if (!project || chatLoading) return;
+    const startChat = useCallback(
+        async (onSuccess?: () => void) => {
+            if (!project || chatLoading) return;
 
-        const targetUserId =
-            project.clientUserId ??
-            project.userId ??
-            project.clientId ??
-            project.writerId ??
-            project.ownerUserId ??
-            null;
+            const token = localStorage.getItem('accessToken');
 
-        const currentUserId = getCurrentUserId();
-        if (currentUserId !== null && targetUserId === currentUserId) {
-            alert('본인에게는 문의할 수 없습니다.');
-            return;
-        }
+            if (!token) {
+                alert('로그인 후 문의할 수 있습니다.');
+                return;
+            }
 
-        if (!targetUserId) {
-            console.error('프로젝트 응답에 작성자 userId가 없습니다.', project);
-            alert('채팅 대상 정보가 없습니다.');
-            return;
-        }
+            const targetUserId =
+                project.clientUserId ??
+                project.userId ??
+                project.clientId ??
+                project.writerId ??
+                project.ownerUserId ??
+                null;
 
-        try {
-            setChatLoading(true);
-            const response = await createOrGetChatRoom(targetUserId);
-            openChat(response.roomId);
-            onSuccess?.();
-        } catch (error) {
-            console.error('채팅방 생성/조회 실패:', error);
-            alert('문의하기를 열지 못했습니다.');
-        } finally {
-            setChatLoading(false);
-        }
-    }, [chatLoading, openChat, project]);
+            const currentUserId = getCurrentUserId();
+
+            if (currentUserId !== null && targetUserId === currentUserId) {
+                alert('본인에게는 문의할 수 없습니다.');
+                return;
+            }
+
+            if (!targetUserId) {
+                console.error('프로젝트 응답에 작성자 userId가 없습니다.', project);
+                alert('채팅 대상 정보가 없습니다.');
+                return;
+            }
+
+            if (!project.projectId) {
+                console.error('프로젝트 응답에 projectId가 없습니다.', project);
+                alert('프로젝트 정보가 올바르지 않습니다.');
+                return;
+            }
+
+            try {
+                setChatLoading(true);
+
+                const response = await createOrGetChatRoom(
+                    targetUserId,
+                    project.projectId
+                );
+
+                openChat(response.roomId);
+                onSuccess?.();
+            } catch (error: any) {
+                console.error('채팅방 생성/조회 실패:', error);
+
+                if (error.response?.status === 400) {
+                    alert('채팅방 생성 요청값이 올바르지 않습니다.');
+                    return;
+                }
+
+                if (error.response?.status === 403) {
+                    alert('채팅방을 생성할 권한이 없습니다.');
+                    return;
+                }
+
+                alert('문의하기를 열지 못했습니다.');
+            } finally {
+                setChatLoading(false);
+            }
+        },
+        [chatLoading, openChat, project]
+    );
 
     const apply = useCallback(async () => {
         if (!projectId) return;
+
         const bid = Number(bidPrice);
+
         if (!bidPrice || !Number.isFinite(bid) || bid <= 0 || !message.trim()) {
             alert('금액과 메시지를 입력해 주세요.');
             return;
         }
+
         setSubmitting(true);
+
         try {
             await api.post('/applications', {
                 projectId,
                 bidPrice: bid,
                 message: message.trim(),
             });
+
             alert('지원이 완료되었습니다!');
             setIsApplied(true);
             setIsApplyOpen(false);
@@ -217,6 +282,7 @@ export function useProjectDetail(projectId: number | null) {
             setSubmitting(false);
         }
     }, [bidPrice, message, projectId]);
+
     return {
         project,
         loading,
@@ -237,4 +303,3 @@ export function useProjectDetail(projectId: number | null) {
         apply,
     };
 }
-

--- a/frontend/app/lib/chatApi.ts
+++ b/frontend/app/lib/chatApi.ts
@@ -30,6 +30,10 @@ export async function markChatAsRead(roomId: number): Promise<void> {
     await api.patch(`/chat/rooms/${roomId}/read`);
 }
 
+export async function leaveChatRoom(roomId: number): Promise<void> {
+    await api.delete(`/chat/rooms/${roomId}`);
+}
+
 export async function sendChatMessage(
     body: ChatMessageSendRequest
 ): Promise<void> {

--- a/frontend/components/chat/ChatWidget.tsx
+++ b/frontend/components/chat/ChatWidget.tsx
@@ -6,6 +6,7 @@ import ChatWindow from "./ChatWindow";
 import {
     getChatMessages,
     getChatRooms,
+    leaveChatRoom,
     markChatAsRead,
     sendChatMessage,
 } from "../../app/lib/chatApi";
@@ -39,16 +40,23 @@ function sortRoomsByLatest(roomList: ChatRoomListResponse[]) {
     });
 }
 
+function hasToken() {
+    if (typeof window === "undefined") return false;
+    return !!localStorage.getItem("accessToken");
+}
+
 export default function ChatWidget() {
     const [view, setView] = useState<ChatView>("list");
     const [input, setInput] = useState("");
     const [rooms, setRooms] = useState<ChatRoomListResponse[]>([]);
     const [messages, setMessages] = useState<ChatMessageResponse[]>([]);
     const [currentUserId, setCurrentUserId] = useState<number | null>(null);
+    const [loggedIn, setLoggedIn] = useState(false);
 
     const [loadingRooms, setLoadingRooms] = useState(false);
     const [loadingMessages, setLoadingMessages] = useState(false);
     const [sending, setSending] = useState(false);
+    const [leaving, setLeaving] = useState(false);
 
     const { isOpen, selectedRoomId, openChat, closeChat, setRoom } = useChatStore();
 
@@ -74,10 +82,48 @@ export default function ChatWidget() {
         ref.current = null;
     };
 
-    useEffect(() => {
+    const syncAuthState = () => {
+        const tokenExists = hasToken();
         const userId = getCurrentUserId();
+
+        setLoggedIn(tokenExists);
         setCurrentUserId(userId);
         currentUserIdRef.current = userId;
+
+        if (!tokenExists) {
+            cleanupSubscription(messageSubscriptionRef);
+            cleanupSubscription(readSubscriptionRef);
+            disconnectChatSocket();
+
+            setInput("");
+            setMessages([]);
+            setRooms([]);
+            setRoom(null);
+            setView("list");
+            closeChat();
+        }
+    };
+
+    useEffect(() => {
+        syncAuthState();
+
+        const handleStorage = () => syncAuthState();
+        const handleFocus = () => syncAuthState();
+        const handleVisibilityChange = () => {
+            if (!document.hidden) {
+                syncAuthState();
+            }
+        };
+
+        window.addEventListener("storage", handleStorage);
+        window.addEventListener("focus", handleFocus);
+        document.addEventListener("visibilitychange", handleVisibilityChange);
+
+        return () => {
+            window.removeEventListener("storage", handleStorage);
+            window.removeEventListener("focus", handleFocus);
+            document.removeEventListener("visibilitychange", handleVisibilityChange);
+        };
     }, []);
 
     useEffect(() => {
@@ -95,6 +141,8 @@ export default function ChatWidget() {
     }, [isOpen, selectedRoomId]);
 
     const fetchRooms = async () => {
+        if (!hasToken()) return;
+
         try {
             setLoadingRooms(true);
 
@@ -128,6 +176,8 @@ export default function ChatWidget() {
     };
 
     const fetchMessages = async (roomId: number) => {
+        if (!hasToken()) return;
+
         const requestId = ++latestMessageReqId.current;
 
         try {
@@ -153,17 +203,17 @@ export default function ChatWidget() {
     };
 
     useEffect(() => {
-        if (!isOpen) return;
+        if (!isOpen || !loggedIn) return;
         fetchRooms();
-    }, [isOpen]);
+    }, [isOpen, loggedIn]);
 
     useEffect(() => {
-        if (!isOpen || !selectedRoomId || view !== "room") return;
+        if (!isOpen || !loggedIn || !selectedRoomId || view !== "room") return;
         fetchMessages(selectedRoomId);
-    }, [isOpen, selectedRoomId, view]);
+    }, [isOpen, loggedIn, selectedRoomId, view]);
 
     useEffect(() => {
-        if (!isOpen) return;
+        if (!isOpen || !loggedIn) return;
 
         connectChatSocket();
 
@@ -172,10 +222,10 @@ export default function ChatWidget() {
             cleanupSubscription(readSubscriptionRef);
             disconnectChatSocket();
         };
-    }, [isOpen]);
+    }, [isOpen, loggedIn]);
 
     useEffect(() => {
-        if (!isOpen || !selectedRoomId) return;
+        if (!isOpen || !loggedIn || !selectedRoomId) return;
 
         let cancelled = false;
 
@@ -257,7 +307,7 @@ export default function ChatWidget() {
 
                                 if (!receipt.read) return;
                                 if (receipt.roomId !== selectedRoomIdRef.current) return;
-                                // Only process when opponent reads; ignore own read events.
+
                                 if (
                                     currentUserIdRef.current !== null &&
                                     receipt.readerId === currentUserIdRef.current
@@ -306,9 +356,15 @@ export default function ChatWidget() {
             cleanupSubscription(messageSubscriptionRef);
             cleanupSubscription(readSubscriptionRef);
         };
-    }, [isOpen, selectedRoomId]);
+    }, [isOpen, loggedIn, selectedRoomId]);
 
     const handleOpenToggle = () => {
+        syncAuthState();
+
+        if (!hasToken()) {
+            return;
+        }
+
         if (isOpen) {
             setInput("");
             setMessages([]);
@@ -338,6 +394,34 @@ export default function ChatWidget() {
         setView("list");
         setInput("");
         await fetchRooms();
+    };
+
+    const handleLeaveRoom = async () => {
+        if (!selectedRoomId || leaving) return;
+
+        const ok = window.confirm("채팅방을 나가시겠습니까?");
+        if (!ok) return;
+
+        try {
+            setLeaving(true);
+            await leaveChatRoom(selectedRoomId);
+
+            cleanupSubscription(messageSubscriptionRef);
+            cleanupSubscription(readSubscriptionRef);
+
+            setRooms((prev) => prev.filter((room) => room.roomId !== selectedRoomId));
+            setMessages([]);
+            setInput("");
+            setRoom(null);
+            setView("list");
+
+            await fetchRooms();
+        } catch (error) {
+            console.error("채팅방 나가기 실패", error);
+            alert("채팅방 나가기에 실패했습니다. 다시 시도해주세요.");
+        } finally {
+            setLeaving(false);
+        }
     };
 
     const handleSend = async () => {
@@ -392,32 +476,36 @@ export default function ChatWidget() {
     return (
         <>
             <ChatWindow
-                isOpen={isOpen}
+                isOpen={isOpen && loggedIn}
                 view={view}
                 onClose={closeChat}
                 onBack={handleBack}
+                onLeaveRoom={handleLeaveRoom}
                 rooms={rooms}
                 selectedRoom={selectedRoom}
                 selectedRoomId={selectedRoomId}
-                onSelectRoom={handleSelectRoom}
                 messages={messages}
                 input={input}
                 onChangeInput={setInput}
+                onSelectRoom={handleSelectRoom}
                 onSend={handleSend}
                 loadingRooms={loadingRooms}
                 loadingMessages={loadingMessages}
                 sending={sending}
+                leaving={leaving}
                 currentUserId={currentUserId}
             />
 
-            <button
-                type="button"
-                onClick={handleOpenToggle}
-                className="fixed bottom-6 right-6 z-[9999] flex h-16 w-16 items-center justify-center rounded-full bg-violet-600 text-2xl text-white shadow-xl transition hover:scale-105 hover:bg-violet-700"
-                aria-label="채팅 열기"
-            >
-                💬
-            </button>
+            {loggedIn && (
+                <button
+                    type="button"
+                    onClick={handleOpenToggle}
+                    className="fixed bottom-6 right-6 z-[9999] flex h-16 w-16 items-center justify-center rounded-full bg-violet-600 text-2xl text-white shadow-xl transition hover:scale-105 hover:bg-violet-700"
+                    aria-label="채팅 열기"
+                >
+                    💬
+                </button>
+            )}
         </>
     );
 }

--- a/frontend/components/chat/ChatWidget.tsx
+++ b/frontend/components/chat/ChatWidget.tsx
@@ -18,6 +18,7 @@ import {
     ensureChatSocketConnected,
 } from "../../app/lib/chatSocket";
 import { getCurrentUserId } from "../../app/lib/auth";
+import { DEVNEAR_AUTH_CHANGED } from "../../app/lib/authEvents";
 import { useChatStore } from "../../app/store/chatStore";
 import type {
     ChatMessageResponse,
@@ -114,15 +115,18 @@ export default function ChatWidget() {
                 syncAuthState();
             }
         };
+        const handleAuthChanged = () => syncAuthState();
 
         window.addEventListener("storage", handleStorage);
         window.addEventListener("focus", handleFocus);
         document.addEventListener("visibilitychange", handleVisibilityChange);
+        window.addEventListener(DEVNEAR_AUTH_CHANGED, handleAuthChanged);
 
         return () => {
             window.removeEventListener("storage", handleStorage);
             window.removeEventListener("focus", handleFocus);
             document.removeEventListener("visibilitychange", handleVisibilityChange);
+            window.removeEventListener(DEVNEAR_AUTH_CHANGED, handleAuthChanged);
         };
     }, []);
 

--- a/frontend/components/chat/ChatWindow.tsx
+++ b/frontend/components/chat/ChatWindow.tsx
@@ -12,6 +12,7 @@ interface ChatWindowProps {
     view: "list" | "room";
     onClose: () => void;
     onBack: () => void;
+    onLeaveRoom: () => void | Promise<void>;
     rooms: ChatRoomListResponse[];
     selectedRoom: ChatRoomListResponse | null;
     selectedRoomId: number | null;
@@ -23,6 +24,7 @@ interface ChatWindowProps {
     loadingRooms: boolean;
     loadingMessages: boolean;
     sending: boolean;
+    leaving?: boolean;
     currentUserId?: number | null;
 }
 
@@ -89,6 +91,7 @@ export default function ChatWindow({
                                        view,
                                        onClose,
                                        onBack,
+                                       onLeaveRoom,
                                        rooms,
                                        selectedRoom,
                                        selectedRoomId,
@@ -100,6 +103,7 @@ export default function ChatWindow({
                                        loadingRooms,
                                        loadingMessages,
                                        sending,
+                                       leaving = false,
                                        currentUserId = null,
                                    }: ChatWindowProps) {
     const [mounted, setMounted] = useState(false);
@@ -173,14 +177,27 @@ export default function ChatWindow({
                     </div>
                 )}
 
-                <button
-                    type="button"
-                    onClick={onClose}
-                    className="text-xl text-gray-400 hover:text-gray-600"
-                    aria-label="채팅 닫기"
-                >
-                    ×
-                </button>
+                <div className="flex items-center gap-3">
+                    {view === "room" && (
+                        <button
+                            type="button"
+                            onClick={onLeaveRoom}
+                            disabled={leaving || !selectedRoomId}
+                            className="text-xs font-medium text-red-500 transition hover:text-red-600 disabled:cursor-not-allowed disabled:text-gray-300"
+                        >
+                            {leaving ? "나가는 중" : "나가기"}
+                        </button>
+                    )}
+
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="text-xl text-gray-400 hover:text-gray-600"
+                        aria-label="채팅 닫기"
+                    >
+                        ×
+                    </button>
+                </div>
             </div>
 
             {view === "list" ? (
@@ -295,9 +312,9 @@ export default function ChatWindow({
                         value={input}
                         onChange={onChangeInput}
                         onSend={onSend}
-                        disabled={sending || !selectedRoomId}
+                        disabled={sending || !selectedRoomId || leaving}
                         sending={sending}
-                        canSend={!!selectedRoomId}
+                        canSend={!!selectedRoomId && !leaving}
                     />
                 </>
             )}


### PR DESCRIPTION
## 🔎 What

- 채팅방 나가기 기능 추가 (soft delete 방식)
- 로그아웃 상태에서 채팅 위젯 비노출 처리
- 나간 채팅방 목록에서 제외
- 동일 사용자 재문의 시 채팅방 복구 처리

## 개선 사항
- WebSocket 구독 안정성 개선
- 빈 채팅방 선택 유지 버그 수정
- 읽음 이벤트 처리 로직 보완

## 비고
- 채팅방은 삭제되지 않고 사용자 기준으로 숨김 처리됩니다.

## 🔗 Issue

- Closes: #177 

## ✅ 체크리스트

- [ ] 브랜치 base가 적절한가요?
- [ ] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Leave Room" button in room header with confirmation and a "Leaving..." state
  * Exited rooms are persisted per participant and hidden from room lists
  * Chat prevents sending while leaving and returns to room list after exit

* **Behavior**
  * Chat UI synchronizes auth state (prevents opening when signed out); launch button shown only when signed in
<!-- end of auto-generated comment: release notes by coderabbit.ai -->