### PR TITLE
Bug/#176 onboarding data error

### DIFF
--- a/backend/src/main/java/com/devnear/global/auth/JwtTokenProvider.java
+++ b/backend/src/main/java/com/devnear/global/auth/JwtTokenProvider.java
@@ -27,7 +27,7 @@ public class JwtTokenProvider {
         this.key = Keys.hmacShaKeyFor(secretString.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String createToken(Long userId, String email, String role) {
+    public String createToken(Long userId, String email, String role, String status) {
         Date now = new Date();
         Date validity = new Date(now.getTime() + validityInMilliseconds);
 
@@ -36,6 +36,7 @@ public class JwtTokenProvider {
                 .subject(email)
                 .claim("userId", userId)
                 .claim("role", role)
+                .claim("status", status) // 🎯 이 부분도 필수!
                 .issuedAt(now)
                 .expiration(validity)
                 .signWith(key)
@@ -60,21 +61,26 @@ public class JwtTokenProvider {
     public Authentication getAuthentication(String token) {
         Claims claims = getClaims(token);
 
-        Long userId = claims.get("userId", Long.class);
+        // 🎯 [핵심 해결책] Integer든 Long이든 일단 Number로 안전하게 꺼낸 뒤, 강제로 Long으로 바꿉니다!
+        Number userIdNumber = claims.get("userId", Number.class);
+        Long userId = userIdNumber != null ? userIdNumber.longValue() : null;
+
         String email = claims.getSubject();
         String role = claims.get("role", String.class);
 
-        // SecurityUser는 마스터의 프로젝트에 정의된 Principal 객체라고 가정합니다.
-        // DB 조회를 생략하고 토큰 정보로만 구성된 SecurityUser를 넘깁니다.
+        // ROLE_ 접두사가 없으면 붙여주는 안전장치 (스프링 시큐리티 꼰대질 방어)
+        if (role != null && !role.startsWith("ROLE_")) {
+            role = "ROLE_" + role;
+        }
+
         SecurityUser principal = new SecurityUser(userId, email, role);
 
         return new UsernamePasswordAuthenticationToken(
                 principal,
                 "",
-                Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role))
+                Collections.singletonList(new SimpleGrantedAuthority(role))
         );
     }
-
     public Claims getClaims(String token) {
         return Jwts.parser()
                 .verifyWith(key)

--- a/backend/src/main/java/com/devnear/global/auth/LoginUserArgumentResolver.java
+++ b/backend/src/main/java/com/devnear/global/auth/LoginUserArgumentResolver.java
@@ -3,8 +3,6 @@ package com.devnear.global.auth;
 import com.devnear.web.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -27,14 +25,6 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
 
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-
-        if (auth == null || !(auth.getPrincipal() instanceof SecurityUser principal)) {
-            return null;
-        }
-
-        // 🎯 [수정] UserContext의 getCurrentUser()는 이제 인자를 받지 않습니다.
-        // 이미 UserContext 내부에서 SecurityContext를 참조하여 유저를 찾아오기 때문입니다.
-        return userContext.getCurrentUser();
+        return userContext.getCurrentUserOrNull();
     }
 }

--- a/backend/src/main/java/com/devnear/global/auth/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/devnear/global/auth/OAuth2SuccessHandler.java
@@ -1,5 +1,8 @@
 package com.devnear.global.auth;
 
+import com.devnear.web.domain.enums.UserStatus;
+import com.devnear.web.domain.user.User;
+import com.devnear.web.domain.user.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +14,6 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.Map;
 
 @Slf4j
 @Component
@@ -19,8 +21,8 @@ import java.util.Map;
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository; // 🎯 확실한 정보 조회를 위해 DB 의존성 주입
 
-    // [보고] 프론트엔드 배포 환경을 고려하여 리다이렉트 URL을 외부화합니다.
     @Value("${app.oauth2.redirect-uri:http://localhost:3000/oauth/redirect}")
     private String redirectUri;
 
@@ -32,27 +34,28 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                                         Authentication authentication) throws IOException {
 
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
-        Map<String, Object> attributes = oAuth2User.getAttributes();
+        String email = (String) oAuth2User.getAttributes().get("email");
 
-        // 1. 유저 상태 검증 (WITHDRAWN 상태인 탈퇴 유저만 입구 컷)
-        String status = (String) attributes.get("status");
-        if ("WITHDRAWN".equals(status)) {
-            log.warn("OAuth2 로그인 차단 - 탈퇴한 계정: {}", attributes.get("email"));
-            // 탈퇴한 계정임을 알리는 프론트엔드 에러 페이지로 리다이렉트
+        // 1. 🎯 구글이 준 이메일로 우리 DB에서 '진짜' 유저 정보를 조회합니다.
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("OAuth2 인증 성공 후 유저를 찾을 수 없습니다: " + email));
+
+        // 2. 유저 상태 검증 (탈퇴 유저 입구 컷)
+        if (user.getStatus() == UserStatus.WITHDRAWN) {
+            log.warn("OAuth2 로그인 차단 - 탈퇴한 계정: {}", email);
             getRedirectStrategy().sendRedirect(request, response, errorUri + "?error=account_withdrawn");
             return;
         }
 
-        // 2. 토큰 재료 준비 (안전한 타입 변환)
-        Object idAttr = attributes.get("id");
-        Long userId = (idAttr instanceof Integer) ? ((Integer) idAttr).longValue() : (Long) idAttr;
-        String email = (String) attributes.get("email");
-        String role = authentication.getAuthorities().iterator().next().getAuthority();
+        // 3. 🎯 토큰 재료 준비 (안전하게 DB 엔티티 사용)
+        Long userId = user.getId();
+        String role = user.getRole().name();
+        String status = user.getStatus().name(); // 🎯 누락되었던 4번째 인자 추가
 
-        // 3. 우리 서비스 전용 JWT 토큰 발급
-        String accessToken = jwtTokenProvider.createToken(userId, email, role);
+        // 4. 우리 서비스 전용 JWT 토큰 발급 (인자 4개 매칭 완료!)
+        String accessToken = jwtTokenProvider.createToken(userId, email, role, status);
 
-        // 4. 보안 강화를 위해 쿼리 스트링(?token=) 대신 프래그먼트(#token=) 사용
+        // 5. 보안 강화를 위해 프래그먼트(#token=) 사용
         String targetUrl = redirectUri + "#token=" + accessToken;
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);

--- a/backend/src/main/java/com/devnear/global/auth/SecurityUser.java
+++ b/backend/src/main/java/com/devnear/global/auth/SecurityUser.java
@@ -50,9 +50,12 @@ public class SecurityUser implements UserDetails {
     @JsonIgnore
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 🎯 [핵심 수정] 이미 ROLE_이 붙어있으면 또 붙이지 않도록 방어합니다!
+        if (role != null && role.startsWith("ROLE_")) {
+            return Collections.singleton(new SimpleGrantedAuthority(role));
+        }
         return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role));
     }
-
     @Override public String getPassword() { return password; }
     @Override public String getUsername() { return email; }
     @Override public boolean isAccountNonExpired() { return true; }

--- a/backend/src/main/java/com/devnear/global/auth/UserContext.java
+++ b/backend/src/main/java/com/devnear/global/auth/UserContext.java
@@ -5,6 +5,7 @@ import com.devnear.web.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -18,19 +19,24 @@ public class UserContext {
     private final UserRepository userRepository;
     private User currentUser;
 
-    /**
-     * 🎯 [핵심] 현재 요청에서 유저 엔티티를 딱 한 번만 조회하여 공유합니다.
-     */
-    public User getCurrentUser() {
+    public User getCurrentUserOrNull() {
         if (currentUser == null) {
             Authentication auth = SecurityContextHolder.getContext().getAuthentication();
             if (auth == null || !(auth.getPrincipal() instanceof SecurityUser principal)) {
                 return null;
             }
-            // ID로 조회하여 N+1 방지용 @EntityGraph가 적용된 메서드 호출
             currentUser = userRepository.findWithProfilesById(principal.getId())
                     .orElseThrow(() -> new IllegalArgumentException("요청한 유저를 찾을 수 없습니다. ID: " + principal.getId()));
         }
         return currentUser;
+    }
+
+
+    public User getRequiredCurrentUser() {
+        User user = getCurrentUserOrNull();
+        if (user == null) {
+            throw new AuthenticationCredentialsNotFoundException("인증된 사용자 정보가 필요합니다.");
+        }
+        return user;
     }
 }

--- a/backend/src/main/java/com/devnear/web/controller/client/ClientController.java
+++ b/backend/src/main/java/com/devnear/web/controller/client/ClientController.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import com.devnear.global.auth.LoginUser;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Client", description = "클라이언트(의뢰인) 프로필 관련 API")
@@ -28,14 +27,20 @@ public class ClientController {
             @LoginUser User user,
             @RequestBody @Valid ClientProfileRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(clientService.registerProfile(user, request)); // email 대신 user 직접 전달
+                .body(clientService.registerProfile(user, request));
     }
 
     @Operation(summary = "클라이언트 프로필 조회", description = "로그인한 유저 본인의 기업 프로필 정보를 가져옵니다.")
     @GetMapping("/profile")
-    public ResponseEntity<ClientProfileResponse> getMyProfile(
-            @LoginUser User user) {
-        return ResponseEntity.ok(clientService.getMyProfile(user));
+    public ResponseEntity<ClientProfileResponse> getMyProfile(@LoginUser User user) {
+        try {
+            // 🎯 [방어 로직] 프로필이 없다고 바로 에러를 터뜨리지 말고, 빈 결과를 주거나 204를 보냅니다.
+            ClientProfileResponse response = clientService.getMyProfile(user);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            // 아직 트랜잭션이 처리 중이거나 프로필이 없는 경우 404 대신 204(No Content)를 반환하여 프론트가 죽지 않게 합니다.
+            return ResponseEntity.noContent().build();
+        }
     }
 
     @Operation(summary = "클라이언트 프로필 수정", description = "로그인한 유저 본인의 기업 정보를 수정합니다.")

--- a/backend/src/main/java/com/devnear/web/domain/client/ClientProfileRepository.java
+++ b/backend/src/main/java/com/devnear/web/domain/client/ClientProfileRepository.java
@@ -2,16 +2,12 @@ package com.devnear.web.domain.client;
 
 import com.devnear.web.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface ClientProfileRepository extends JpaRepository<ClientProfile, Long> {
-
-    Optional<ClientProfile> findByUser(User user);
 
     Optional<ClientProfile> findByUser_Id(Long userId);
 
@@ -20,4 +16,4 @@ public interface ClientProfileRepository extends JpaRepository<ClientProfile, Lo
     boolean existsByBn(String bn);
 
     boolean existsByBnAndIdNot(String bn, Long id);
-}
+}

--- a/backend/src/main/java/com/devnear/web/domain/client/ClientProfileRepository.java
+++ b/backend/src/main/java/com/devnear/web/domain/client/ClientProfileRepository.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 @Repository
 public interface ClientProfileRepository extends JpaRepository<ClientProfile, Long> {
 
+    Optional<ClientProfile> findByUser(User user);
+
     Optional<ClientProfile> findByUser_Id(Long userId);
 
     boolean existsByUser(User user);

--- a/backend/src/main/java/com/devnear/web/domain/user/User.java
+++ b/backend/src/main/java/com/devnear/web/domain/user/User.java
@@ -98,11 +98,6 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.notifyCommunityComments = notifyCommunityComments;
     }
 
-    /**
-     * {@code findByEmailForUpdate} 등으로 User만 잠그면 역방향 OneToOne이 비어 있을 수 있습니다.
-     * 이때 flush 시 {@code orphanRemoval}으로 프로필이 삭제되면 타인의 찜 등 FK가 깨질 수 있어,
-     * 저장소에서 읽은 프로필로 필드를 맞춥니다.
-     */
     public void attachManagedProfiles(ClientProfile clientProfile, FreelancerProfile freelancerProfile) {
         if (clientProfile != null) {
             this.clientProfile = clientProfile;
@@ -129,9 +124,6 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.profileImageUrl = profileImageUrl;
     }
 
-    /**
-     * 회원탈퇴: 로그인 불가·PII 제거. 프로필/리뷰 등 연관 엔티티는 서비스에서 별도 스크럽합니다.
-     */
     public void markWithdrawnAndAnonymize(String uniqueEmail, String uniqueNickname, String encodedPasswordPlaceholder) {
         this.email = uniqueEmail;
         this.password = encodedPasswordPlaceholder;
@@ -144,9 +136,19 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.status = UserStatus.WITHDRAWN;
     }
 
-    // 🔍 [추가] 닉네임 수정을 위한 세터 메서드
     public void setNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    // ==========================================
+    // 🎯 [핵심 추가] JPA 삭제 방어용 Setter 메서드
+    // ==========================================
+    public void setClientProfile(ClientProfile clientProfile) {
+        this.clientProfile = clientProfile;
+    }
+
+    public void setFreelancerProfile(FreelancerProfile freelancerProfile) {
+        this.freelancerProfile = freelancerProfile;
     }
 
     // ================= UserDetails 필수 구현 메서드 =================

--- a/backend/src/main/java/com/devnear/web/service/user/UserService.java
+++ b/backend/src/main/java/com/devnear/web/service/user/UserService.java
@@ -2,6 +2,7 @@ package com.devnear.web.service.user;
 
 import com.devnear.global.auth.JwtTokenProvider;
 import com.devnear.global.auth.UserContext;
+import com.devnear.web.domain.client.ClientProfile;
 import com.devnear.web.domain.client.ClientProfileRepository;
 import com.devnear.web.domain.enums.Role;
 import com.devnear.web.domain.enums.UserStatus;
@@ -15,8 +16,8 @@ import com.devnear.web.domain.user.UserRepository;
 import com.devnear.web.dto.freelancer.FreelancerProfileRequest;
 import com.devnear.web.dto.user.*;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Objects;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -35,20 +37,16 @@ public class UserService {
     private final ClientProfileRepository clientProfileRepository;
     private final FreelancerProfileRepository freelancerProfileRepository;
     private final SkillRepository skillRepository;
-    private final UserContext userContext; // 🎯 보관함 주입
+    private final UserContext userContext;
 
     @Transactional
     public Long register(UserRegisterRequest request) {
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
         }
-        try {
-            String encodedPassword = passwordEncoder.encode(request.getPassword());
-            User user = request.toEntity(encodedPassword);
-            return userRepository.save(user).getId();
-        } catch (DataIntegrityViolationException e) {
-            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
-        }
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        User user = request.toEntity(encodedPassword);
+        return userRepository.save(user).getId();
     }
 
     @Transactional
@@ -60,100 +58,88 @@ public class UserService {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        String token = jwtTokenProvider.createToken(user.getId(), user.getEmail(), user.getRole().name());
+        String token = jwtTokenProvider.createToken(user.getId(), user.getEmail(), user.getRole().name(), user.getStatus().name());
         return new TokenResponse(token, "Bearer");
     }
 
-    /**
-     * 🎯 [최적화] email로 다시 조회하지 않고 UserContext에서 가져옵니다.
-     */
     @CacheEvict(value = "users", allEntries = true)
     @Transactional
     public TokenResponse onboarding(String email, OnboardingRequest request) {
-        User user = userContext.getCurrentUser(); // 🚀 DB 안 가고 보관함에서 꺼냄
+        User user = userContext.getRequiredCurrentUser();
 
-        if (user.getStatus() == UserStatus.WITHDRAWN) {
-            throw new IllegalArgumentException("탈퇴 처리된 계정입니다.");
-        }
-
-        if (!Objects.equals(user.getNickname(), request.getNickname()) &&
-                userRepository.existsByNickname(request.getNickname())) {
-            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+        if (user.getStatus() == UserStatus.WITHDRAWN) throw new IllegalArgumentException("탈퇴 계정");
+        if (!Objects.equals(user.getNickname(), request.getNickname()) && userRepository.existsByNickname(request.getNickname())) {
+            throw new IllegalArgumentException("중복 닉네임");
         }
 
         user.onboard(request.getNickname(), request.getRole());
 
+        // 🎯 1. 클라이언트 프로필 처리
         if (request.getRole() == Role.CLIENT || request.getRole() == Role.BOTH) {
             if (user.getClientProfile() != null) {
                 user.getClientProfile().update(request.getClientProfile());
             } else {
-                clientProfileRepository.save(request.getClientProfile().toEntity(user));
+                ClientProfile clientProfile = request.getClientProfile().toEntity(user);
+                clientProfileRepository.save(clientProfile);
+
+                // 🎯 [방어막 작동] 메모리의 User에게 프로필 연결!
+                user.setClientProfile(clientProfile);
+                log.info("🎯 Client Profile Linked & Saved for User: {}", user.getId());
             }
         }
 
+        // 🎯 2. 프리랜서 프로필 처리
         if (request.getRole() == Role.FREELANCER || request.getRole() == Role.BOTH) {
-            if (user.getFreelancerProfile() != null) {
-                throw new IllegalStateException("이미 프리랜서 프로필이 존재합니다.");
+            if (user.getFreelancerProfile() == null) {
+                FreelancerProfileRequest fReq = request.getFreelancerProfile();
+                FreelancerProfile profile = FreelancerProfile.builder()
+                        .user(user)
+                        .introduction(fReq.getIntroduction())
+                        .location(fReq.getLocation())
+                        .latitude(fReq.getLatitude())
+                        .longitude(fReq.getLongitude())
+                        .hourlyRate(fReq.getHourlyRate())
+                        .workStyle(fReq.getWorkStyle())
+                        .isActive(true)
+                        .build();
+
+                List<FreelancerSkill> skills = fReq.getSkillIds().stream()
+                        .map(skillId -> {
+                            Skill skill = skillRepository.findById(skillId).orElseThrow();
+                            return FreelancerSkill.builder().freelancerProfile(profile).skill(skill).build();
+                        }).toList();
+
+                profile.updateSkills(skills);
+                freelancerProfileRepository.save(profile);
+
+                // 🎯 [방어막 작동] 메모리의 User에게 프로필 연결!
+                user.setFreelancerProfile(profile);
+                log.info("🎯 Freelancer Profile Linked & Saved for User: {}", user.getId());
             }
-
-            FreelancerProfileRequest fReq = request.getFreelancerProfile();
-            FreelancerProfile profile = FreelancerProfile.builder()
-                    .user(user)
-                    .introduction(fReq.getIntroduction())
-                    .location(fReq.getLocation())
-                    .latitude(fReq.getLatitude())
-                    .longitude(fReq.getLongitude())
-                    .hourlyRate(fReq.getHourlyRate())
-                    .workStyle(fReq.getWorkStyle())
-                    .isActive(true)
-                    .build();
-
-            List<FreelancerSkill> skills = fReq.getSkillIds().stream()
-                    .map(skillId -> {
-                        Skill skill = skillRepository.findById(skillId)
-                                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스킬 ID입니다: " + skillId));
-                        return FreelancerSkill.builder()
-                                .freelancerProfile(profile)
-                                .skill(skill)
-                                .build();
-                    })
-                    .toList();
-
-            profile.updateSkills(skills);
-            freelancerProfileRepository.save(profile);
         }
 
-        String newToken = jwtTokenProvider.createToken(user.getId(), user.getEmail(), user.getRole().name());
-        return new TokenResponse(newToken, "Bearer");
+        userRepository.saveAndFlush(user);
+
+        return new TokenResponse(
+                jwtTokenProvider.createToken(user.getId(), user.getEmail(), user.getRole().name(), user.getStatus().name()),
+                "Bearer"
+        );
     }
 
-    /**
-     * 🎯 [최적화] 단순히 내 정보를 가져올 때도 UserContext 활용
-     */
     public UserInfoResponse getUserInfo(String email) {
-        User user = userContext.getCurrentUser();
-        return new UserInfoResponse(user);
+        return new UserInfoResponse(userContext.getRequiredCurrentUser());
     }
 
     @Transactional
     public UserInfoResponse updateNotificationPreferences(String email, NotificationPreferencePatchRequest request) {
-        User user = userContext.getCurrentUser();
-        if (user.getStatus() == UserStatus.WITHDRAWN) {
-            throw new IllegalArgumentException("탈퇴 처리된 계정입니다.");
-        }
-        if (request.getNotifyCommunityComments() != null) {
-            user.setNotifyCommunityComments(request.getNotifyCommunityComments());
-        }
+        User user = userContext.getRequiredCurrentUser();
+        if (request.getNotifyCommunityComments() != null) user.setNotifyCommunityComments(request.getNotifyCommunityComments());
         return new UserInfoResponse(user);
     }
 
     @CacheEvict(value = "users", allEntries = true)
     @Transactional
     public void updateProfileImage(String email, String newImageUrl) {
-        User user = userContext.getCurrentUser();
-        if (user.getStatus() == UserStatus.WITHDRAWN) {
-            throw new IllegalArgumentException("탈퇴 처리된 계정입니다.");
-        }
-        user.updateProfileImageUrl(newImageUrl);
+        userContext.getRequiredCurrentUser().updateProfileImageUrl(newImageUrl);
     }
 }

--- a/backend/src/main/java/com/devnear/web/service/user/UserService.java
+++ b/backend/src/main/java/com/devnear/web/service/user/UserService.java
@@ -22,6 +22,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -80,10 +81,10 @@ public class UserService {
                 user.getClientProfile().update(request.getClientProfile());
             } else {
                 ClientProfile clientProfile = request.getClientProfile().toEntity(user);
-                clientProfileRepository.save(clientProfile);
 
-                // 🎯 [방어막 작동] 메모리의 User에게 프로필 연결!
-                user.setClientProfile(clientProfile);
+                // 🎯 [수정] save()가 반환하는 영속(Managed) 객체를 받아서 연결
+                ClientProfile savedClientProfile = clientProfileRepository.save(clientProfile);
+                user.setClientProfile(savedClientProfile);
                 log.info("🎯 Client Profile Linked & Saved for User: {}", user.getId());
             }
         }
@@ -103,17 +104,30 @@ public class UserService {
                         .isActive(true)
                         .build();
 
-                List<FreelancerSkill> skills = fReq.getSkillIds().stream()
-                        .map(skillId -> {
-                            Skill skill = skillRepository.findById(skillId).orElseThrow();
-                            return FreelancerSkill.builder().freelancerProfile(profile).skill(skill).build();
-                        }).toList();
+                // 스킬 유효성 검증 및 N+1 문제 해결 (이전 수정본 반영)
+                List<FreelancerSkill> skills = new ArrayList<>();
+                List<Long> requestedSkillIds = fReq.getSkillIds();
+
+                if (requestedSkillIds != null && !requestedSkillIds.isEmpty()) {
+                    List<Skill> validSkills = skillRepository.findAllById(requestedSkillIds);
+
+                    if (validSkills.size() != requestedSkillIds.size()) {
+                        throw new IllegalArgumentException("존재하지 않는 기술 스택 ID가 포함되어 있습니다.");
+                    }
+
+                    skills = validSkills.stream()
+                            .map(skill -> FreelancerSkill.builder()
+                                    .freelancerProfile(profile)
+                                    .skill(skill)
+                                    .build())
+                            .toList();
+                }
 
                 profile.updateSkills(skills);
-                freelancerProfileRepository.save(profile);
 
-                // 🎯 [방어막 작동] 메모리의 User에게 프로필 연결!
-                user.setFreelancerProfile(profile);
+                // 🎯 [수정] save()가 반환하는 영속(Managed) 객체를 받아서 연결합니다.
+                FreelancerProfile savedFreelancerProfile = freelancerProfileRepository.save(profile);
+                user.setFreelancerProfile(savedFreelancerProfile);
                 log.info("🎯 Freelancer Profile Linked & Saved for User: {}", user.getId());
             }
         }
@@ -133,13 +147,28 @@ public class UserService {
     @Transactional
     public UserInfoResponse updateNotificationPreferences(String email, NotificationPreferencePatchRequest request) {
         User user = userContext.getRequiredCurrentUser();
-        if (request.getNotifyCommunityComments() != null) user.setNotifyCommunityComments(request.getNotifyCommunityComments());
+
+        // 탈퇴 계정 방어막
+        if (user.getStatus() == UserStatus.WITHDRAWN) {
+            throw new IllegalArgumentException("탈퇴 계정입니다.");
+        }
+
+        if (request.getNotifyCommunityComments() != null) {
+            user.setNotifyCommunityComments(request.getNotifyCommunityComments());
+        }
         return new UserInfoResponse(user);
     }
 
     @CacheEvict(value = "users", allEntries = true)
     @Transactional
     public void updateProfileImage(String email, String newImageUrl) {
-        userContext.getRequiredCurrentUser().updateProfileImageUrl(newImageUrl);
+        User user = userContext.getRequiredCurrentUser();
+
+        // 탈퇴 계정 방어막
+        if (user.getStatus() == UserStatus.WITHDRAWN) {
+            throw new IllegalArgumentException("탈퇴 계정입니다.");
+        }
+
+        user.updateProfileImageUrl(newImageUrl);
     }
 }

--- a/frontend/app/client/dashboard/page.tsx
+++ b/frontend/app/client/dashboard/page.tsx
@@ -81,7 +81,9 @@ export default function ClientDashboardPage() {
         const checkAccess = async () => {
             try {
                 const res = await api.get("/v1/users/me");
+                console.log("🔥 [진실의 로그] 대시보드 권한 데이터:", res.data);
                 const roles = res.data.role || "";
+
                 if (!roles.includes("CLIENT") && !roles.includes("BOTH")) {
                     alert("클라이언트 또는 BOTH 계정만 접근 가능합니다.");
                     if (roles.includes("FREELANCER")) return router.replace("/");

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -78,7 +78,16 @@ export default function OnboardingPage() {
             if (role === "FREELANCER" || role === "BOTH") onboardingPayload.freelancerProfile = freelancerData;
 
             const res = await api.post("/v1/users/onboarding", onboardingPayload);
+            // 🎯 [이 줄을 추가하십시오!] 백엔드가 도대체 뭘 줬는지 통째로 출력해 봅니다.
+            console.log("🔥 백엔드 응답 전체 데이터:", res.data);
             const newToken = res.data.accessToken;
+
+            if (newToken) {
+                localStorage.setItem("accessToken", newToken); // 여기서 덮어씌워짐
+                notifyAuthChanged();
+            } else {
+                console.error("백엔드가 토큰을 안 줬습니다!"); // 만약 토큰이 안왔다면 여기서 걸립니다.
+            }
 
             if (newToken) {
                 localStorage.setItem("accessToken", newToken);
@@ -86,8 +95,10 @@ export default function OnboardingPage() {
             }
 
             alert("권한 설정 완료!");
-            // 🎯 [수정] 하드코딩된 경로 대신 공통 모듈을 사용하여 일관성을 확보했습니다.
-            router.replace(postLoginPathForRole(role));
+            setTimeout(() => {
+                // 🎯 백엔드 트랜잭션이 완전히 끝날 수 있도록 1초(1000ms)만 기다림
+                window.location.href = postLoginPathForRole(role);
+            }, 1000);
 
         } catch (err: any) {
             alert("설정 중 오류가 발생했습니다.");


### PR DESCRIPTION
## 🔎 What
🛠️ 해결 내용 (Technical Solution)

양방향 연관관계 일치화 (핵심 원인 해결)
User 엔티티의 orphanRemoval = true 옵션으로 인해, 부모 객체인 User가 자식 객체(Profile)를 참조하지 않을 경우 JPA가 이를 고아 객체로 판단하여 삭제하는 것을 확인
UserService.onboarding()에서 프로필 저장 후 user.setClientProfile(profile) 등을 호출하여 메모리 상의 객체 그래프를 일치

엔티티 보강
User 엔티티에 연관관계 설정을 위한 Setter 메서드를 추가

방어적 프로그래밍 (백엔드)
ClientController.getMyProfile 호출 시 데이터가 아직 DB에 완전히 안착하지 않은 찰나의 순간을 대비해 try-catch로 204 No Content를 반환하도록 개선

프론트엔드 최적화
온보딩 API 호출 후 리다이렉트 시 setTimeout을 이용해 1초의 대기 시간을 부여, 백엔드 트랜잭션이 완료될 시간을 확보
## 🔗 Issue

- Closes: #176 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database query patterns to improve application performance and reduce data retrieval latency
  * Enhanced backend infrastructure with caching capabilities and SQL query monitoring for better observability
  * Streamlined service layer logic for improved code quality and system stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->