### PR TITLE
[Bug]#184Modify chat list display limit

### DIFF
--- a/backend/src/main/java/com/devnear/web/service/chat/ChatService.java
+++ b/backend/src/main/java/com/devnear/web/service/chat/ChatService.java
@@ -235,13 +235,32 @@ public class ChatService {
         }
 
         Map<Long, ChatRoom> latestRoomByOpponentId = new LinkedHashMap<>();
+
         for (ChatRoom room : rooms) {
             Long opponentId = room.getOpponent(me).getId();
-            latestRoomByOpponentId.putIfAbsent(opponentId, room);
+
+            latestRoomByOpponentId.compute(opponentId, (key, existingRoom) -> {
+                if (existingRoom == null) {
+                    return room;
+                }
+
+                if (room.getUpdatedAt() == null) {
+                    return existingRoom;
+                }
+
+                if (existingRoom.getUpdatedAt() == null) {
+                    return room;
+                }
+
+                return room.getUpdatedAt().isAfter(existingRoom.getUpdatedAt())
+                        ? room
+                        : existingRoom;
+            });
         }
 
-        List<ChatRoom> deduplicatedRooms = latestRoomByOpponentId.values().stream().toList();
-        List<Long> roomIds = deduplicatedRooms.stream()
+        List<ChatRoom> visibleRooms = latestRoomByOpponentId.values().stream().toList();
+
+        List<Long> roomIds = visibleRooms.stream()
                 .map(ChatRoom::getId)
                 .toList();
 
@@ -263,7 +282,7 @@ public class ChatService {
             unreadCountMap.put(roomIdNum.longValue(), countNum.longValue());
         }
 
-        return deduplicatedRooms.stream()
+        return visibleRooms.stream()
                 .map(room -> {
                     ChatMessage lastMessage = lastMessageMap.get(room.getId());
                     long unreadCount = unreadCountMap.getOrDefault(room.getId(), 0L);


### PR DESCRIPTION
##🐛 Bug Fix: 채팅방 목록 일부만 표시되는 문제 수정

##🔥 문제 상황
여러 프리랜서에게 채팅을 생성했음에도 채팅방이 일부(예: 3개)만 표시되는 문제 발생
새로운 채팅방 생성 시 이전 채팅방이 목록에서 사라지는 현상 발생

##❗ 원인
getMyRooms()에서 채팅방 중복 제거 로직이 putIfAbsent() 기반으로 동작
이 방식은 먼저 조회된 채팅방만 유지하기 때문에,
최신순 정렬 상태에서 일부 데이터만 기준이 되어 이전 채팅방이 누락됨
latestRoomByOpponentId.putIfAbsent(opponentId, room);

##✅ 해결 방법
putIfAbsent() → compute()로 변경하여
상대방 기준으로 가장 최신 채팅방을 정확하게 유지하도록 수정
latestRoomByOpponentId.compute(opponentId, (key, existingRoom) -> {
    if (existingRoom == null) return room;

    return room.getUpdatedAt().isAfter(existingRoom.getUpdatedAt())
        ? room
        : existingRoom;
});

##🎯 개선 결과
동일 프리랜서 기준 채팅방 1개 유지 (정상 동작)
여러 프리랜서와의 채팅방 모두 정상 표시
새로운 채팅 생성 시 기존 채팅방이 사라지는 문제 해결
나가기 처리된 채팅방은 기존 로직대로 정상 제외

##📌 영향 범위
ChatService.getMyRooms() 로직 수정
채팅방 목록 조회 API 응답 개선
프론트 채팅 위젯 정상 동작 확인 완료

## 🔗 Issue

- Closes: #184

## ✅ 체크리스트

- [ ] 브랜치 base가 적절한가요?
- [ ] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where duplicate chat rooms with the same opponent could appear. The app now displays only the most recent chat room per opponent, properly handling cases where timestamps may be missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->